### PR TITLE
Add emulator/UDP

### DIFF
--- a/trezord.go
+++ b/trezord.go
@@ -5,15 +5,41 @@ import (
 	"io"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/trezor/trezord-go/server"
 	"github.com/trezor/trezord-go/usb"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
+type udpPorts []int
+
+func (i *udpPorts) String() string {
+	res := ""
+	for i, p := range *i {
+		if i > 0 {
+			res = res + ","
+		}
+		res = res + strconv.Itoa(p)
+	}
+	return res
+}
+
+func (i *udpPorts) Set(value string) error {
+	p, err := strconv.Atoi(value)
+	if err != nil {
+		return nil
+	}
+	*i = append(*i, p)
+	return nil
+}
+
 func main() {
 	var logfile string
+	var ports udpPorts
+
 	flag.StringVar(&logfile, "l", "", "Log into a file, rotating after 5MB")
+	flag.Var(&ports, "e", "Use UDP port for emulator. Can be repeated for more ports. Example: trezord-go -e 21324 -e 21326")
 	flag.Parse()
 
 	var logger io.WriteCloser
@@ -36,7 +62,18 @@ func main() {
 	if err != nil {
 		log.Fatalf("hidapi: %s", err)
 	}
-	b := usb.Init(w, h)
+
+	var b *usb.USB
+
+	if len(ports) > 0 {
+		e, err := usb.InitUDP(ports)
+		if err != nil {
+			log.Fatalf("emulator: %s", err)
+		}
+		b = usb.Init(w, h, e)
+	} else {
+		b = usb.Init(w, h)
+	}
 
 	s, err := server.New(b, logger)
 	if err != nil {

--- a/usb/bus.go
+++ b/usb/bus.go
@@ -68,3 +68,4 @@ func (b *USB) Connect(path string) (Device, error) {
 }
 
 var disconnectError = errors.New("Device disconnected during action")
+var closedDeviceError = errors.New("Closed device")

--- a/usb/udp.go
+++ b/usb/udp.go
@@ -1,0 +1,175 @@
+package usb
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+var emulatorPing = []byte("PINGPING")
+var emulatorPong = []byte("PONGPONG")
+
+const (
+	emulatorPrefix            = "emulator"
+	emulatorAddress           = "127.0.0.1"
+	emulatorPingTimeout       = 50 * time.Millisecond
+	emulatorDisconnectTimeout = 200 * time.Millisecond
+)
+
+type UDP struct {
+	ports []int
+
+	pings   map[int](chan []byte)
+	datas   map[int](chan []byte)
+	writers map[int](io.Writer)
+}
+
+func listen(conn net.Conn) (chan []byte, chan []byte) {
+	ping := make(chan []byte, 1)
+	data := make(chan []byte, 100)
+	go func() {
+		for {
+			buffer := make([]byte, 64)
+			_, err := conn.Read(buffer)
+			if err == nil {
+				first := buffer[0]
+				if first == '?' {
+					data <- buffer
+				}
+				if first == 'P' {
+					copied := make([]byte, 8)
+					copy(copied, buffer)
+					ping <- copied
+				}
+			}
+		}
+	}()
+	return ping, data
+}
+
+func InitUDP(ports []int) (*UDP, error) {
+	udp := UDP{
+		ports: ports,
+
+		pings:   make(map[int](chan []byte)),
+		datas:   make(map[int](chan []byte)),
+		writers: make(map[int](io.Writer)),
+	}
+	for _, port := range ports {
+		address := emulatorAddress + ":" + strconv.Itoa(port)
+
+		connection, err := net.Dial("udp", address)
+		if err != nil {
+			return nil, err
+		}
+
+		ping, data := listen(connection)
+		udp.pings[port] = ping
+		udp.datas[port] = data
+		udp.writers[port] = connection
+	}
+	return &udp, nil
+}
+
+func checkPort(ping chan []byte, w io.Writer) (bool, error) {
+	_, err := w.Write(emulatorPing)
+	if err != nil {
+		return false, err
+	}
+	select {
+	case response := <-ping:
+		return bytes.Equal(response, emulatorPong), nil
+	case <-time.After(emulatorPingTimeout):
+		return false, nil
+	}
+}
+
+func (u *UDP) Enumerate() ([]Info, error) {
+	var infos []Info
+
+	for _, port := range u.ports {
+		ping := u.pings[port]
+		w := u.writers[port]
+		present, err := checkPort(ping, w)
+		if err != nil {
+			return nil, err
+		}
+		if present {
+			infos = append(infos, Info{
+				Path:      emulatorPrefix + strconv.Itoa(port),
+				VendorID:  0,
+				ProductID: 0,
+			})
+		}
+	}
+	return infos, nil
+}
+
+func (u *UDP) Has(path string) bool {
+	return strings.HasPrefix(path, emulatorPrefix)
+}
+
+func (u *UDP) Connect(path string) (Device, error) {
+	i, err := strconv.Atoi(strings.TrimPrefix(path, emulatorPrefix))
+	if err != nil {
+		return nil, err
+	}
+	return &UDPDevice{
+		ping:   u.pings[i],
+		data:   u.datas[i],
+		writer: u.writers[i],
+		closed: 0,
+	}, nil
+}
+
+type UDPDevice struct {
+	ping   chan []byte
+	data   chan []byte
+	writer io.Writer
+
+	closed int32 // atomic
+}
+
+func (d *UDPDevice) Close() error {
+	atomic.StoreInt32(&d.closed, 1)
+	return nil
+}
+
+func (d *UDPDevice) readWrite(buf []byte, read bool) (int, error) {
+	for {
+		closed := (atomic.LoadInt32(&d.closed)) == 1
+		if closed {
+			return 0, closedDeviceError
+		}
+		check, err := checkPort(d.ping, d.writer)
+		if err != nil {
+			return 0, err
+		}
+		if !check {
+			return 0, disconnectError
+		}
+		if !read {
+			return d.writer.Write(buf)
+		} else {
+			select {
+			case response := <-d.data:
+				copy(buf, response)
+				return len(response), nil
+			case <-time.After(emulatorPingTimeout):
+				// timeout, continue for cycle
+			}
+		}
+	}
+}
+
+func (d *UDPDevice) Write(buf []byte) (int, error) {
+	return d.readWrite(buf, false)
+}
+
+func (d *UDPDevice) Read(buf []byte) (int, error) {
+	return d.readWrite(buf, true)
+}

--- a/usb/webusb.go
+++ b/usb/webusb.go
@@ -2,7 +2,6 @@ package usb
 
 import (
 	"encoding/hex"
-	"errors"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -162,8 +161,6 @@ func (d *WUD) Close() error {
 
 	return nil
 }
-
-var closedDeviceError = errors.New("Closed device")
 
 func (d *WUD) readWrite(buf []byte, endpoint uint8) (int, error) {
 	for {


### PR DESCRIPTION
This differs from this PR https://github.com/trezor/trezord-go/pull/9 in some ways

It is correctly handling turning off the emulator during the call. That is useful for testing states of user disconnecting the device. However, that adds a significant complexity, since some incoming packets "belong" to the detections and some "belong" to the reader, which is solved here by the channels.

Also, the emulators are not called by default, but only when a flag is present

`trezord-go -e 21324 -e 21326`

When there are no ports, the layer is not inited at all.