### PR TITLE
Fix trezord shell path (nologin -> false)

### DIFF
--- a/release/linux/fpm.before-install.sh
+++ b/release/linux/fpm.before-install.sh
@@ -1,6 +1,6 @@
 getent group trezord >/dev/null || groupadd -r trezord
 getent group plugdev >/dev/null || groupadd -r plugdev
-getent passwd trezord >/dev/null || useradd -r -g trezord -d /var -s /sbin/nologin -c "TREZOR Bridge" trezord
+getent passwd trezord >/dev/null || useradd -r -g trezord -d /var -s /bin/false -c "TREZOR Bridge" trezord
 usermod -a -G plugdev trezord
 touch /var/log/trezord.log
 chown trezord:trezord /var/log/trezord.log


### PR DESCRIPTION
`/sbin/nologin` is located at `/usr/sbin/nologin` on Debian/Ubuntu systems and either way the shell should never be used so `/bin/false` is probably better (see https://unix.stackexchange.com/a/10867 for the difference between the two)