### PR TITLE
Added url parameter for /td <algorithm> switch from SignTool.

### DIFF
--- a/release/windows/release.sh
+++ b/release/windows/release.sh
@@ -18,7 +18,7 @@ SIGNKEY=/release/authenticode
 
 if [ -r $SIGNKEY.der ]; then
     mv trezord.exe trezord.exe.unsigned
-    osslsigncode sign -certs $SIGNKEY.p7b -key $SIGNKEY.der -n "TREZOR Bridge" -i "https://trezor.io/" -t http://timestamp.comodoca.com -in trezord.exe.unsigned -out trezord.exe
+    osslsigncode sign -certs $SIGNKEY.p7b -key $SIGNKEY.der -n "TREZOR Bridge" -i "https://trezor.io/" -t "http://timestamp.comodoca.com?td=sha256" -in trezord.exe.unsigned -out trezord.exe
     osslsigncode verify -in trezord.exe
 fi
 
@@ -30,6 +30,6 @@ fi
 
 if [ -r $SIGNKEY.der ]; then
     mv $INSTALLER $INSTALLER.unsigned
-    osslsigncode sign -certs $SIGNKEY.p7b -key $SIGNKEY.der -n "TREZOR Bridge" -i "https://trezor.io/" -t http://timestamp.comodoca.com -in $INSTALLER.unsigned -out $INSTALLER
+    osslsigncode sign -certs $SIGNKEY.p7b -key $SIGNKEY.der -n "TREZOR Bridge" -i "https://trezor.io/" -t "http://timestamp.comodoca.com?td=sha256" -in $INSTALLER.unsigned -out $INSTALLER
     osslsigncode verify -in $INSTALLER
 fi


### PR DESCRIPTION
This is a very simple pull request to go along with the discussion in [this ticket](https://github.com/trezor/trezord-go/issues/42).

To sum up the findings : 

As it appears you are using authenticode in the background as part of osslsigncode the url parameter is all that is needed to generate a SHA256 timestamp, provided that the signing certificate was SHA256 as well.

If you are using the RFC 3161 timestamp a second parameter is needed in the request, /td, in which the algorithm is specified.