### PR TITLE
Add more detailed logs

### DIFF
--- a/memorywriter/memorywriter.go
+++ b/memorywriter/memorywriter.go
@@ -1,6 +1,8 @@
 package memorywriter
 
 import (
+	"bytes"
+	"compress/gzip"
 	"errors"
 )
 
@@ -12,7 +14,7 @@ type MemoryWriter struct {
 	lines        [][]byte // lines include newlines
 }
 
-func (m *MemoryWriter) Write(p []byte) (n int, err error) {
+func (m *MemoryWriter) Write(p []byte) (int, error) {
 	if len(p) > maxLineLength {
 		return 0, errors.New("Input too long")
 	}
@@ -27,7 +29,7 @@ func (m *MemoryWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func (t *MemoryWriter) String() string {
+func (t *MemoryWriter) String(start string) string {
 	res := make([]byte, 0)
 
 	for i := len(t.lines) - 1; i >= 0; i-- {
@@ -35,7 +37,7 @@ func (t *MemoryWriter) String() string {
 		res = append(res, line...)
 	}
 
-	return string(res)
+	return start + string(res)
 }
 
 func New(size int) *MemoryWriter {
@@ -43,4 +45,40 @@ func New(size int) *MemoryWriter {
 		maxLineCount: size,
 		lines:        make([][]byte, 0, size),
 	}
+}
+
+func (t *MemoryWriter) gzip(start string) ([]byte, error) {
+	var buf bytes.Buffer
+	gw, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	if err != nil {
+		return nil, err
+	}
+
+	gw.Name = "log.txt"
+	gw.Write([]byte(start))
+
+	for i := len(t.lines) - 1; i >= 0; i-- {
+		line := t.lines[i]
+		gw.Write(line)
+	}
+
+	err = gw.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), err
+}
+
+func (t *MemoryWriter) GzipJsArray(start string) ([]int, error) {
+	zip, err := t.gzip(start)
+	if err != nil {
+		return nil, err
+	}
+	res := make([]int, 0, len(zip))
+
+	for _, b := range zip {
+		res = append(res, int(b))
+	}
+	return res, nil
 }

--- a/server/devcon_shim.go
+++ b/server/devcon_shim.go
@@ -2,6 +2,10 @@
 
 package server
 
-func devconInfo() (string, error) {
+import (
+	"log"
+)
+
+func devconInfo(dlogger *log.Logger) (string, error) {
 	return "", nil
 }

--- a/server/http.go
+++ b/server/http.go
@@ -45,10 +45,11 @@ type Server struct {
 	callMutex      sync.Mutex // for atomic access to callInProgress, plus prevent enumeration
 	lastInfos      []usb.Info // when call is in progress, use saved info for enumerating
 
-	mw *memorywriter.MemoryWriter
+	mw, dmw         *memorywriter.MemoryWriter
+	logger, dlogger *log.Logger
 }
 
-func New(bus *usb.USB, logger io.Writer, mw *memorywriter.MemoryWriter) (*Server, error) {
+func New(bus *usb.USB, logWriter io.Writer, mw, dmw *memorywriter.MemoryWriter, logger, dlogger *log.Logger) (*Server, error) {
 	https := &http.Server{
 		Addr: "127.0.0.1:21325",
 	}
@@ -57,7 +58,10 @@ func New(bus *usb.USB, logger io.Writer, mw *memorywriter.MemoryWriter) (*Server
 		https:    https,
 		sessions: make(map[string]*session),
 
-		mw: mw,
+		mw:      mw,
+		dmw:     dmw,
+		logger:  logger,
+		dlogger: dlogger,
 	}
 	r := mux.NewRouter()
 
@@ -85,18 +89,18 @@ func New(bus *usb.USB, logger io.Writer, mw *memorywriter.MemoryWriter) (*Server
 	// Restrict cross-origin access.
 	h = CORS(v)(h)
 	// Log after the request is done, in the Apache format.
-	h = handlers.LoggingHandler(logger, h)
+	h = handlers.LoggingHandler(logWriter, h)
 	// Log when the request is received.
-	h = logRequest(h)
+	h = s.logRequest(h)
 
 	https.Handler = h
 
 	return s, nil
 }
 
-func logRequest(handler http.Handler) http.Handler {
+func (s *Server) logRequest(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("%s %s", r.Method, r.URL)
+		s.logger.Printf("%s %s", r.Method, r.URL)
 		handler.ServeHTTP(w, r)
 	})
 }
@@ -143,7 +147,7 @@ func (s *Server) Close() error {
 func (s *Server) StatusPage(w http.ResponseWriter, r *http.Request) {
 	e, err := s.enumerate()
 	if err != nil {
-		respondError(w, err)
+		s.respondError(w, err)
 		return
 	}
 
@@ -174,23 +178,26 @@ func (s *Server) StatusPage(w http.ResponseWriter, r *http.Request) {
 		tdevs = append(tdevs, tdev)
 	}
 
+	origDetailedLog := s.dmw.String()
 	origLog := s.mw.String()
 	devconLog, err := devconInfo()
 	if err != nil {
-		respondError(w, err)
+		s.respondError(w, err)
 		return
 	}
 	log := devconLog + origLog
+	dlog := devconLog + origDetailedLog
 
 	data := &statusTemplateData{
 		Version:     version,
 		Devices:     tdevs,
 		DeviceCount: len(tdevs),
 		Log:         log,
+		DLog:        dlog,
 	}
 
 	err = statusTemplate.Execute(w, data)
-	checkJSONError(w, err)
+	s.checkJSONError(w, err)
 }
 
 func (s *Server) Info(w http.ResponseWriter, r *http.Request) {
@@ -200,7 +207,7 @@ func (s *Server) Info(w http.ResponseWriter, r *http.Request) {
 	err := json.NewEncoder(w).Encode(info{
 		Version: version,
 	})
-	checkJSONError(w, err)
+	s.checkJSONError(w, err)
 }
 
 type entry struct {
@@ -235,12 +242,12 @@ func (s *Server) Listen(w http.ResponseWriter, r *http.Request) {
 		errClose := r.Body.Close()
 		if errClose != nil {
 			// just log
-			log.Printf("Error on request close: %s", errClose.Error())
+			s.logger.Printf("Error on request close: %s", errClose.Error())
 		}
 	}()
 
 	if err != nil {
-		respondError(w, err)
+		s.respondError(w, err)
 		return
 	}
 
@@ -249,7 +256,7 @@ func (s *Server) Listen(w http.ResponseWriter, r *http.Request) {
 	for i := 0; i < iterMax; i++ {
 		e, enumErr := s.enumerate()
 		if enumErr != nil {
-			respondError(w, enumErr)
+			s.respondError(w, enumErr)
 			return
 		}
 		if reflect.DeepEqual(entries, e) {
@@ -265,17 +272,17 @@ func (s *Server) Listen(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	err = json.NewEncoder(w).Encode(entries)
-	checkJSONError(w, err)
+	s.checkJSONError(w, err)
 }
 
 func (s *Server) Enumerate(w http.ResponseWriter, r *http.Request) {
 	e, err := s.enumerate()
 	if err != nil {
-		respondError(w, err)
+		s.respondError(w, err)
 		return
 	}
 	err = json.NewEncoder(w).Encode(e)
-	checkJSONError(w, err)
+	s.checkJSONError(w, err)
 }
 
 func (s *Server) enumerate() ([]entry, error) {
@@ -341,7 +348,7 @@ func (s *Server) releaseDisconnected(infos []usb.Info) {
 			// just log if there is an error
 			// they are disconnected anyway
 			if err != nil {
-				log.Printf("Error on releasing disconnected device: %s", err)
+				s.logger.Printf("Error on releasing disconnected device: %s", err)
 			}
 		}
 	}
@@ -376,21 +383,21 @@ func (s *Server) Acquire(w http.ResponseWriter, r *http.Request) {
 		acquired = &session{path: path, call: 0}
 	}
 	if acquired.id != prev {
-		respondError(w, ErrWrongPrevSession)
+		s.respondError(w, ErrWrongPrevSession)
 		return
 	}
 
 	if prev != "" {
 		err := s.release(prev)
 		if err != nil {
-			respondError(w, err)
+			s.respondError(w, err)
 			return
 		}
 	}
 
 	dev, err := s.tryConnect(path)
 	if err != nil {
-		respondError(w, err)
+		s.respondError(w, err)
 		return
 	}
 
@@ -406,7 +413,7 @@ func (s *Server) Acquire(w http.ResponseWriter, r *http.Request) {
 	err = json.NewEncoder(w).Encode(result{
 		Session: acquired.id,
 	})
-	checkJSONError(w, err)
+	s.checkJSONError(w, err)
 }
 
 // Chrome tries to read from trezor immediately after connecting,
@@ -450,12 +457,12 @@ func (s *Server) Release(w http.ResponseWriter, r *http.Request) {
 	err := s.release(session)
 
 	if err != nil {
-		respondError(w, err)
+		s.respondError(w, err)
 		return
 	}
 
 	err = json.NewEncoder(w).Encode(vars)
-	checkJSONError(w, err)
+	s.checkJSONError(w, err)
 }
 
 func (s *Server) Call(w http.ResponseWriter, r *http.Request) {
@@ -492,7 +499,7 @@ func (s *Server) call(w http.ResponseWriter, r *http.Request, skipRead bool) {
 	s.sessionsMutex.Unlock()
 
 	if acquired == nil {
-		respondError(w, ErrSessionNotFound)
+		s.respondError(w, ErrSessionNotFound)
 		return
 	}
 
@@ -518,19 +525,19 @@ func (s *Server) call(w http.ResponseWriter, r *http.Request, skipRead bool) {
 			errRelease := s.release(session)
 			if errRelease != nil {
 				// just log, since request is already closed
-				log.Printf("Error while releasing: %s", errRelease.Error())
+				s.logger.Printf("Error while releasing: %s", errRelease.Error())
 			}
 		}
 	}()
 
-	err := readWriteDev(w, r, acquired.dev, skipRead)
+	err := s.readWriteDev(w, r, acquired.dev, skipRead)
 	if err != nil {
-		respondError(w, err)
+		s.respondError(w, err)
 	}
 }
 
-func readWriteDev(w io.Writer, r *http.Request, d io.ReadWriter, skipRead bool) error {
-	msg, err := decodeRaw(r.Body)
+func (s *Server) readWriteDev(w io.Writer, r *http.Request, d io.ReadWriter, skipRead bool) error {
+	msg, err := s.decodeRaw(r.Body)
 	if err != nil {
 		return err
 	}
@@ -557,7 +564,7 @@ func (s *Server) newSession() string {
 	return strconv.Itoa(latestSessionID)
 }
 
-func decodeRaw(r io.Reader) (*wire.Message, error) {
+func (s *Server) decodeRaw(r io.Reader) (*wire.Message, error) {
 	body, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -583,6 +590,8 @@ func decodeRaw(r io.Reader) (*wire.Message, error) {
 	return &wire.Message{
 		Kind: kind,
 		Data: data,
+
+		Dlogger: s.dlogger,
 	}, nil
 }
 
@@ -606,13 +615,13 @@ func encodeRaw(w io.Writer, msg *wire.Message) error {
 	return err
 }
 
-func checkJSONError(w http.ResponseWriter, err error) {
+func (s *Server) checkJSONError(w http.ResponseWriter, err error) {
 	if err != nil {
-		respondError(w, err)
+		s.respondError(w, err)
 	}
 }
 
-func respondError(w http.ResponseWriter, err error) {
+func (s *Server) respondError(w http.ResponseWriter, err error) {
 	type jsonError struct {
 		Error string `json:"error"`
 	}
@@ -623,6 +632,6 @@ func respondError(w http.ResponseWriter, err error) {
 		Error: err.Error(),
 	})
 	if err != nil {
-		log.Printf("Error while writing error: %s", err.Error())
+		s.logger.Printf("Error while writing error: %s", err.Error())
 	}
 }

--- a/server/http.go
+++ b/server/http.go
@@ -184,24 +184,30 @@ func (s *Server) StatusPage(w http.ResponseWriter, r *http.Request) {
 
 	s.dlogger.Println("http - asking devcon")
 
-	origDetailedLog := s.dmw.String()
-	origLog := s.mw.String()
 	devconLog, err := devconInfo(s.dlogger)
 	if err != nil {
 		s.respondError(w, err)
 		return
 	}
-	log := devconLog + origLog
-	dlog := devconLog + origDetailedLog
+
+	start := version + "\n" + devconLog
+
+	log := s.mw.String(start)
+	gziplog, err := s.dmw.GzipJsArray(start)
+
+	if err != nil {
+		s.respondError(w, err)
+		return
+	}
 
 	s.dlogger.Println("http - actually building status data")
 
 	data := &statusTemplateData{
-		Version:     version,
-		Devices:     tdevs,
-		DeviceCount: len(tdevs),
-		Log:         log,
-		DLog:        dlog,
+		Version:        version,
+		Devices:        tdevs,
+		DeviceCount:    len(tdevs),
+		Log:            log,
+		DLogGzipJSData: gziplog,
 	}
 
 	err = statusTemplate.Execute(w, data)

--- a/server/http.go
+++ b/server/http.go
@@ -192,7 +192,12 @@ func (s *Server) StatusPage(w http.ResponseWriter, r *http.Request) {
 
 	start := version + "\n" + devconLog
 
-	log := s.mw.String(start)
+	log, err := s.mw.String(start)
+	if err != nil {
+		s.respondError(w, err)
+		return
+	}
+
 	gziplog, err := s.dmw.GzipJsArray(start)
 
 	if err != nil {

--- a/server/statustemplate.go
+++ b/server/statustemplate.go
@@ -18,11 +18,11 @@ type statusTemplateDevice struct {
 }
 
 type statusTemplateData struct {
-	Version     string
-	Devices     []statusTemplateDevice
-	DeviceCount int
-	Log         string
-	DLog        string
+	Version        string
+	Devices        []statusTemplateDevice
+	DeviceCount    int
+	Log            string
+	DLogGzipJSData []int
 }
 
 const templateString = `
@@ -158,16 +158,11 @@ const templateString = `
       {{end}}
 
        <div class="space-top">
-       <p>Console Log</p>
-       <p>
-         <input type="checkbox" id="detailLogCheckbox">
-         <label for="detailLogCheckbox">Show detailed log</label>
+       <p>Console Log
+        (<a href="" id="detlog">download detailed log</a>)
        </p>
        <textarea rows="25" cols="150" id="log">
 {{.Log}}
-       </textarea>
-       <textarea rows="25" cols="150" id="dlog">
-{{.DLog}}
        </textarea>
      </div>
 
@@ -180,15 +175,13 @@ const templateString = `
     </div>
   </div>
   <script>
-    document.getElementById("detailLogCheckbox").onchange = function () {
-      if (document.getElementById("detailLogCheckbox").checked) {
-        document.getElementById("dlog").style.display = "inline-block";
-        document.getElementById("log").style.display = "none";
-      } else {
-        document.getElementById("log").style.display = "inline-block";
-        document.getElementById("dlog").style.display = "none";
-      }
-    }
+   var gzipByteArray = new Uint8Array({{.DLogGzipJSData}});
+   var blob = new Blob([gzipByteArray], {type: "application/gzip"});
+   var a = document.getElementById("detlog")
+   var url = window.URL.createObjectURL(blob);
+
+   a.href = url;
+   a.download = "log.gz";
   </script>
 </body>
 </html>

--- a/server/statustemplate.go
+++ b/server/statustemplate.go
@@ -159,11 +159,13 @@ const templateString = `
 
        <div class="space-top">
        <p>Console Log
-        (<a href="" id="detlog">download detailed log</a>)
        </p>
        <textarea rows="25" cols="150" id="log">
 {{.Log}}
        </textarea>
+       <p>
+        <a href="" id="detlog">download detailed log</a>
+       </p>
      </div>
 
       <div class="space-top">

--- a/server/statustemplate.go
+++ b/server/statustemplate.go
@@ -22,6 +22,7 @@ type statusTemplateData struct {
 	Devices     []statusTemplateDevice
 	DeviceCount int
 	Log         string
+	DLog        string
 }
 
 const templateString = `
@@ -118,6 +119,10 @@ const templateString = `
     textarea{
       max-width: 700px;
     }
+
+    #dlog {
+      display: none;
+    }
   </style>
 </head>
 
@@ -154,8 +159,15 @@ const templateString = `
 
        <div class="space-top">
        <p>Console Log</p>
-       <textarea rows="25" cols="150">
+       <p>
+         <input type="checkbox" id="detailLogCheckbox">
+         <label for="detailLogCheckbox">Show detailed log</label>
+       </p>
+       <textarea rows="25" cols="150" id="log">
 {{.Log}}
+       </textarea>
+       <textarea rows="25" cols="150" id="dlog">
+{{.DLog}}
        </textarea>
      </div>
 
@@ -167,6 +179,17 @@ const templateString = `
       </div>
     </div>
   </div>
+  <script>
+    document.getElementById("detailLogCheckbox").onchange = function () {
+      if (document.getElementById("detailLogCheckbox").checked) {
+        document.getElementById("dlog").style.display = "inline-block";
+        document.getElementById("log").style.display = "none";
+      } else {
+        document.getElementById("log").style.display = "inline-block";
+        document.getElementById("dlog").style.display = "none";
+      }
+    }
+  </script>
 </body>
 </html>
 `

--- a/trezord.go
+++ b/trezord.go
@@ -58,7 +58,7 @@ func main() {
 
 	m := memorywriter.New(2000)
 
-	detailedLogWriter := memorywriter.New(3000)
+	detailedLogWriter := memorywriter.New(90000)
 	logWriter := io.MultiWriter(lw, m, detailedLogWriter)
 
 	logger := log.New(logWriter, "", log.LstdFlags)

--- a/trezord.go
+++ b/trezord.go
@@ -56,9 +56,9 @@ func main() {
 		lw = os.Stderr
 	}
 
-	m := memorywriter.New(2000)
+	m := memorywriter.New(2000, 200)
 
-	detailedLogWriter := memorywriter.New(90000)
+	detailedLogWriter := memorywriter.New(90000, 200)
 	logWriter := io.MultiWriter(lw, m, detailedLogWriter)
 
 	logger := log.New(logWriter, "", log.LstdFlags)

--- a/usb/hidapi.go
+++ b/usb/hidapi.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"log"
 	"strings"
 
 	"github.com/trezor/usbhid"
@@ -16,10 +17,14 @@ const (
 )
 
 type HIDAPI struct {
+	logger, detailedLogger *log.Logger
 }
 
-func InitHIDAPI() (*HIDAPI, error) {
-	return &HIDAPI{}, nil
+func InitHIDAPI(logger, detailedLogger *log.Logger) (*HIDAPI, error) {
+	return &HIDAPI{
+		logger:         logger,
+		detailedLogger: detailedLogger,
+	}, nil
 }
 
 func (b *HIDAPI) Enumerate() ([]Info, error) {

--- a/usb/webusb.go
+++ b/usb/webusb.go
@@ -21,42 +21,56 @@ const (
 )
 
 type WebUSB struct {
-	usb                    usbhid.Context
-	logger, detailedLogger *log.Logger
+	usb             usbhid.Context
+	logger, dlogger *log.Logger
 }
 
-func InitWebUSB(logger, detailedLogger *log.Logger) (*WebUSB, error) {
+func InitWebUSB(logger, dlogger *log.Logger) (*WebUSB, error) {
 	var usb usbhid.Context
+	dlogger.Println("webusb - init")
 	err := usbhid.Init(&usb)
 	if err != nil {
 		return nil, err
 	}
 	usbhid.Set_Debug(usb, int(usbhid.LOG_LEVEL_NONE))
 
+	dlogger.Println("webusb - init done")
+
 	return &WebUSB{
-		usb:            usb,
-		logger:         logger,
-		detailedLogger: detailedLogger,
+		usb:     usb,
+		logger:  logger,
+		dlogger: dlogger,
 	}, nil
 }
 
 func (b *WebUSB) Close() {
+	b.dlogger.Println("webusb - all close (should happen only on exit)")
 	usbhid.Exit(b.usb)
 }
 
 func (b *WebUSB) Enumerate() ([]Info, error) {
+	b.dlogger.Println("webusb - enum - low level enumerating")
 	list, err := usbhid.Get_Device_List(b.usb)
+
 	if err != nil {
 		return nil, err
 	}
-	defer usbhid.Free_Device_List(list, 1) // unlink devices
+	b.dlogger.Println("webusb - enum - low level enumerating done")
+
+	defer func() {
+		b.dlogger.Println("webusb - enum - freeing device list")
+		usbhid.Free_Device_List(list, 1) // unlink devices
+		b.dlogger.Println("webusb - enum - freeing device list done")
+	}()
 
 	var infos []Info
 
 	for _, dev := range list {
 		if b.match(dev) {
+			b.dlogger.Println("webusb - enum - getting device descriptor")
 			dd, err := usbhid.Get_Device_Descriptor(dev)
 			if err != nil {
+				b.dlogger.Printf("webusb - enum - error getting device descriptor %s", err.Error())
 				continue
 			}
 			infos = append(infos, Info{
@@ -74,11 +88,19 @@ func (b *WebUSB) Has(path string) bool {
 }
 
 func (b *WebUSB) Connect(path string) (Device, error) {
+	b.dlogger.Println("webusb - connect - low level enumerating")
 	list, err := usbhid.Get_Device_List(b.usb)
+
 	if err != nil {
 		return nil, err
 	}
-	defer usbhid.Free_Device_List(list, 1) // unlink devices
+	b.dlogger.Println("webusb - connect - low level enumerating done")
+
+	defer func() {
+		b.dlogger.Println("webusb - connect - freeing device list")
+		usbhid.Free_Device_List(list, 1) // unlink devices
+		b.dlogger.Println("webusb - connect - freeing device list done")
+	}()
 
 	for _, dev := range list {
 		if b.match(dev) && b.identify(dev) == path {
@@ -89,10 +111,12 @@ func (b *WebUSB) Connect(path string) (Device, error) {
 }
 
 func (b *WebUSB) connect(dev usbhid.Device) (*WUD, error) {
+	b.dlogger.Println("webusb - connect - low level")
 	d, err := usbhid.Open(dev)
 	if err != nil {
 		return nil, err
 	}
+	b.dlogger.Println("webusb - connect - reset")
 	err = usbhid.Reset_Device(d)
 	if err != nil {
 		// don't abort if reset fails
@@ -100,6 +124,17 @@ func (b *WebUSB) connect(dev usbhid.Device) (*WUD, error) {
 		// return nil, err
 		b.logger.Printf("Warning: error at device reset: %s", err)
 	}
+
+	{
+		currConf, err := usbhid.Get_Configuration(d)
+		if err != nil {
+			b.dlogger.Printf("webusb - connect - current configuration err %s", err.Error())
+		} else {
+			b.dlogger.Printf("webusb - connect - current configuration %d", currConf)
+		}
+	}
+
+	b.dlogger.Println("webusb - connect - set_configuration")
 	err = usbhid.Set_Configuration(d, webConfigNum)
 	if err != nil {
 		// don't abort if set configuration fails
@@ -107,20 +142,38 @@ func (b *WebUSB) connect(dev usbhid.Device) (*WUD, error) {
 		// return nil, err
 		b.logger.Printf("Warning: error at configuration set: %s", err)
 	}
+
+	{
+		currConf, err := usbhid.Get_Configuration(d)
+		if err != nil {
+			b.dlogger.Printf("webusb - connect - current configuration err %s", err.Error())
+		} else {
+			b.dlogger.Printf("webusb - connect - current configuration %d", currConf)
+		}
+	}
+
+	b.dlogger.Println("webusb - connect - claiming interface")
 	err = usbhid.Claim_Interface(d, webIfaceNum)
 	if err != nil {
+		b.dlogger.Println("webusb - connect - claiming interface failed")
 		usbhid.Close(d)
 		return nil, err
 	}
+
+	b.dlogger.Println("webusb - connect - claiming interface done")
+
 	return &WUD{
 		dev:    d,
 		closed: 0,
+
+		dlogger: b.dlogger,
 	}, nil
 }
 
 func (b *WebUSB) match(dev usbhid.Device) bool {
 	dd, err := usbhid.Get_Device_Descriptor(dev)
 	if err != nil {
+		b.dlogger.Println("webusb - match - error getting descriptor", err.Error())
 		return false
 	}
 
@@ -132,6 +185,7 @@ func (b *WebUSB) match(dev usbhid.Device) bool {
 
 	c, err := usbhid.Get_Active_Config_Descriptor(dev)
 	if err != nil {
+		b.dlogger.Printf("webusb - match - error getting config descriptor %s", err.Error())
 		return false
 	}
 	return (c.BNumInterfaces > webIfaceNum &&
@@ -149,6 +203,7 @@ func (b *WebUSB) identify(dev usbhid.Device) string {
 	var ports [8]byte
 	p, err := usbhid.Get_Port_Numbers(dev, ports[:])
 	if err != nil {
+		b.dlogger.Printf("webusb - identify - error getting port numbers %s", err.Error())
 		return ""
 	}
 	return webusbPrefix + hex.EncodeToString(p)
@@ -162,58 +217,82 @@ type WUD struct {
 	transferMutex sync.Mutex
 	// closing cannot happen while interrupt_transfer is hapenning,
 	// otherwise interrupt_transfer hangs forever
+
+	dlogger *log.Logger
 }
 
 func (d *WUD) Close() error {
+	d.dlogger.Println("webusb - close - storing d.closed")
 	atomic.StoreInt32(&d.closed, 1)
 
+	d.dlogger.Println("webusb - close - finishing read queue")
 	d.finishReadQueue()
 
+	d.dlogger.Println("webusb - close - wait for transferMutex lock")
 	d.transferMutex.Lock()
+	d.dlogger.Println("webusb - close - low level close")
 	usbhid.Close(d.dev)
 	d.transferMutex.Unlock()
+
+	d.dlogger.Println("webusb - close - done")
 
 	return nil
 }
 
 func (d *WUD) finishReadQueue() {
+	d.dlogger.Println("webusb - close - rq - wait for transfermutex lock")
 	d.transferMutex.Lock()
 	var err error
 	var buf [64]byte
 
 	for err == nil {
+		d.dlogger.Println("webusb - close - rq - transfer")
 		_, err = usbhid.Interrupt_Transfer(d.dev, webEpIn, buf[:], 50)
 	}
 	d.transferMutex.Unlock()
+	d.dlogger.Println("webusb - close - rq - done")
 }
 
 func (d *WUD) readWrite(buf []byte, endpoint uint8) (int, error) {
+	d.dlogger.Println("webusb - rw - start")
 	for {
+		d.dlogger.Println("webusb - rw - checking closed")
 		closed := (atomic.LoadInt32(&d.closed)) == 1
 		if closed {
+			d.dlogger.Println("webusb - rw - closed, skip")
 			return 0, errClosedDevice
 		}
 
+		d.dlogger.Println("webusb - rw - lock transfer mutex")
 		d.transferMutex.Lock()
+		d.dlogger.Println("webusb - rw - actual interrupt transport")
 		p, err := usbhid.Interrupt_Transfer(d.dev, endpoint, buf, usbTimeout)
 		d.transferMutex.Unlock()
+		d.dlogger.Println("webusb - rw - single transfer done")
 
 		if err == nil {
 			// sometimes, empty report is read, skip it
 			if len(p) > 0 {
+				d.dlogger.Println("webusb - rw - single transfer succesful")
 				return len(p), err
+			} else {
+				d.dlogger.Println("webusb - rw - skipping empty transfer - go again")
 			}
 		}
 
 		if err != nil {
+			d.dlogger.Printf("webusb - rw - error seen - %s", err.Error())
 			if err.Error() == usbhid.Error_Name(int(usbhid.ERROR_IO)) ||
 				err.Error() == usbhid.Error_Name(int(usbhid.ERROR_NO_DEVICE)) {
+				d.dlogger.Println("webusb - rw - device probably disconnected")
 				return 0, errDisconnect
 			}
 
 			if err.Error() != usbhid.Error_Name(int(usbhid.ERROR_TIMEOUT)) {
+				d.dlogger.Println("webusb - rw - other error")
 				return 0, err
 			}
+			d.dlogger.Println("webusb - rw - timeout - go again")
 		}
 
 		// continue the for cycle
@@ -221,9 +300,11 @@ func (d *WUD) readWrite(buf []byte, endpoint uint8) (int, error) {
 }
 
 func (d *WUD) Write(buf []byte) (int, error) {
+	d.dlogger.Println("webusb - rw - write start")
 	return d.readWrite(buf, webEpOut)
 }
 
 func (d *WUD) Read(buf []byte) (int, error) {
+	d.dlogger.Println("webusb - rw - read start")
 	return d.readWrite(buf, webEpIn)
 }

--- a/usb/webusb.go
+++ b/usb/webusb.go
@@ -21,10 +21,11 @@ const (
 )
 
 type WebUSB struct {
-	usb usbhid.Context
+	usb                    usbhid.Context
+	logger, detailedLogger *log.Logger
 }
 
-func InitWebUSB() (*WebUSB, error) {
+func InitWebUSB(logger, detailedLogger *log.Logger) (*WebUSB, error) {
 	var usb usbhid.Context
 	err := usbhid.Init(&usb)
 	if err != nil {
@@ -33,7 +34,9 @@ func InitWebUSB() (*WebUSB, error) {
 	usbhid.Set_Debug(usb, int(usbhid.LOG_LEVEL_NONE))
 
 	return &WebUSB{
-		usb: usb,
+		usb:            usb,
+		logger:         logger,
+		detailedLogger: detailedLogger,
 	}, nil
 }
 
@@ -95,14 +98,14 @@ func (b *WebUSB) connect(dev usbhid.Device) (*WUD, error) {
 		// don't abort if reset fails
 		// usbhid.Close(d)
 		// return nil, err
-		log.Printf("Warning: error at device reset: %s", err)
+		b.logger.Printf("Warning: error at device reset: %s", err)
 	}
 	err = usbhid.Set_Configuration(d, webConfigNum)
 	if err != nil {
 		// don't abort if set configuration fails
 		// usbhid.Close(d)
 		// return nil, err
-		log.Printf("Warning: error at configuration set: %s", err)
+		b.logger.Printf("Warning: error at configuration set: %s", err)
 	}
 	err = usbhid.Claim_Interface(d, webIfaceNum)
 	if err != nil {

--- a/usb/webusb.go
+++ b/usb/webusb.go
@@ -125,13 +125,11 @@ func (b *WebUSB) connect(dev usbhid.Device) (*WUD, error) {
 		b.logger.Printf("Warning: error at device reset: %s", err)
 	}
 
-	{
-		currConf, err := usbhid.Get_Configuration(d)
-		if err != nil {
-			b.dlogger.Printf("webusb - connect - current configuration err %s", err.Error())
-		} else {
-			b.dlogger.Printf("webusb - connect - current configuration %d", currConf)
-		}
+	currConf, err := usbhid.Get_Configuration(d)
+	if err != nil {
+		b.dlogger.Printf("webusb - connect - current configuration err %s", err.Error())
+	} else {
+		b.dlogger.Printf("webusb - connect - current configuration %d", currConf)
 	}
 
 	b.dlogger.Println("webusb - connect - set_configuration")
@@ -143,13 +141,11 @@ func (b *WebUSB) connect(dev usbhid.Device) (*WUD, error) {
 		b.logger.Printf("Warning: error at configuration set: %s", err)
 	}
 
-	{
-		currConf, err := usbhid.Get_Configuration(d)
-		if err != nil {
-			b.dlogger.Printf("webusb - connect - current configuration err %s", err.Error())
-		} else {
-			b.dlogger.Printf("webusb - connect - current configuration %d", currConf)
-		}
+	currConf, err = usbhid.Get_Configuration(d)
+	if err != nil {
+		b.dlogger.Printf("webusb - connect - current configuration err %s", err.Error())
+	} else {
+		b.dlogger.Printf("webusb - connect - current configuration %d", currConf)
 	}
 
 	b.dlogger.Println("webusb - connect - claiming interface")
@@ -275,9 +271,8 @@ func (d *WUD) readWrite(buf []byte, endpoint uint8) (int, error) {
 			if len(p) > 0 {
 				d.dlogger.Println("webusb - rw - single transfer succesful")
 				return len(p), err
-			} else {
-				d.dlogger.Println("webusb - rw - skipping empty transfer - go again")
 			}
+			d.dlogger.Println("webusb - rw - skipping empty transfer - go again")
 		}
 
 		if err != nil {

--- a/wire/v1.go
+++ b/wire/v1.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"log"
 )
 
 const (
@@ -15,6 +16,8 @@ const (
 type Message struct {
 	Kind uint16
 	Data []byte
+
+	Dlogger *log.Logger
 }
 
 func (m *Message) WriteTo(w io.Writer) (int64, error) {

--- a/wire/v1.go
+++ b/wire/v1.go
@@ -21,6 +21,8 @@ type Message struct {
 }
 
 func (m *Message) WriteTo(w io.Writer) (int64, error) {
+	m.Dlogger.Println("v1 - writeTo - start")
+
 	var (
 		rep  [packetLen]byte
 		kind = m.Kind
@@ -32,6 +34,8 @@ func (m *Message) WriteTo(w io.Writer) (int64, error) {
 	rep[2] = repMagic
 	binary.BigEndian.PutUint16(rep[3:], kind)
 	binary.BigEndian.PutUint32(rep[5:], size)
+
+	m.Dlogger.Println("v1 - writeTo - actually writing")
 
 	var (
 		written = 0 // number of written bytes
@@ -68,6 +72,7 @@ var (
 )
 
 func (m *Message) ReadFrom(r io.Reader) (int64, error) {
+	m.Dlogger.Println("v1 - readFrom - start")
 	var (
 		rep  [packetLen]byte
 		read = 0 // number of read bytes
@@ -79,12 +84,15 @@ func (m *Message) ReadFrom(r io.Reader) (int64, error) {
 
 	// skip all the previous messages in the bus
 	for rep[0] != repMarker || rep[1] != repMagic || rep[2] != repMagic {
+		m.Dlogger.Println("v1 - readFrom - detected previous message, skipping")
 		n, err = r.Read(rep[:])
 		if err != nil {
 			return int64(read), err
 		}
 	}
 	read += n
+
+	m.Dlogger.Println("v1 - readFrom - actual reading started")
 
 	// parse header
 	var (
@@ -109,6 +117,8 @@ func (m *Message) ReadFrom(r io.Reader) (int64, error) {
 
 	m.Kind = kind
 	m.Data = data
+
+	m.Dlogger.Println("v1 - readFrom - actual reading finished")
 
 	return int64(read), nil
 }


### PR DESCRIPTION
To better diagnose USB issues, I have added very crazy detailed logging.

This logs are kept just in memory, just around 10MB of them, and they are offered for download at the status page (as gzip, done through golang gzip + javascript blob download link)