### PR TITLE
macos: Sign the installer

### DIFF
--- a/release/macos/release.sh
+++ b/release/macos/release.sh
@@ -76,3 +76,32 @@ rm -r /release/build/flat-install
 rm uninstall.pkg
 
 mv install.pkg $INSTALLER
+
+# In order to get the necessary files for signing, do the following:
+# 1) register as Apple developer, get signing certificate from Apple (can take months)
+# 2) On Mac, install XCode, generate certificates with type "Developer ID Installer"
+# 3) On Mac, still in XCode, right-click in on the cert and select "export", That creates cert.p12 file (with passphrase)
+# 4) On Mac, do `productsign --sign 'Developer ID Installer: YourDeveloperId' 'unsigned-package.pkg' 'signed-package.pkg'`
+#     where YourDeveloperId is your developer ID and unsigned-package is an unsigned package (this needs to be done only once)
+# 5) Copy the cert.p12 and signed-package.pkg to Linux
+# 6) On linux, do `mkdir certs ; xar -f signed-package.pkg --extract-certs certs`, that puts cert00, cert01 and cert02 in the certs dir
+# 7) On linux, do `openssl pkcs12 -in cert.p12 -nodes | openssl rsa -out key.pem`, that creates key.pem
+
+# The cert00, cert01 and cert02 files can now be used for pkg signing.
+
+
+# sign the installer
+PRIVKEY=/release/key.pem
+if [ -r $PRIVKEY ]; then
+    SIGNLEN=$(: | openssl dgst -sign $PRIVKEY -binary | wc -c)
+    xar --sign -f $INSTALLER --digestinfo-to-sign digestinfo.dat \
+      --sig-size $SIGNLEN \
+      --cert-loc /release/cert00 \
+      --cert-loc /release/cert01 \
+      --cert-loc /release/cert02
+    openssl rsautl -sign -inkey $PRIVKEY -in digestinfo.dat \
+      -out signature.dat
+    xar --inject-sig signature.dat -f $INSTALLER
+    rm -f signature.dat digestinfo.dat
+fi
+


### PR DESCRIPTION
Requires files extracted from certificate given by Apple, as described here

http://users.wfu.edu/cottrell/productsign/productsign_linux.html

Add files `cert00`, `cert01`, `cert02` and `key.pem` to release/macos/