### PR TITLE
Fix CORS rejections for node applications

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -216,11 +216,10 @@ func corsValidator() (OriginValidator, error) {
 			return true
 		}
 
-		// `null` is for electron apps or chrome extensions.
-		// commented out for now
-		// if origin == "null" {
-		//	return true
-		// }
+		// `null` and `` are for electron apps or chrome extensions.
+		if origin == "null" || origin == "" {
+			return true
+		}
 
 		if tregex.MatchString(origin) {
 			return true


### PR DESCRIPTION
Closes #68. Uncomments the condition for null origins. That alone didn't work though, so I also added a check for empty string. Not sure if the check for "null" actually does anything, but I assume it was initially written for a reason, so I left it. I can confirm that this allows my node application to communicate with my TREZOR via the `trezor.js` library.