### PR TITLE
errors should not be capitalized

### DIFF
--- a/memorywriter/memorywriter.go
+++ b/memorywriter/memorywriter.go
@@ -29,7 +29,7 @@ func (m *MemoryWriter) Println(s string) {
 // Writer remembers lines in memory
 func (m *MemoryWriter) Write(p []byte) (int, error) {
 	if len(p) > maxLineLength {
-		return 0, errors.New("Input too long")
+		return 0, errors.New("input too long")
 	}
 	newline := make([]byte, len(p))
 	copy(newline, p)

--- a/usb/bus.go
+++ b/usb/bus.go
@@ -56,5 +56,5 @@ func (b *USB) Connect(path string) (Device, error) {
 	return nil, ErrNotFound
 }
 
-var errDisconnect = errors.New("Device disconnected during action")
-var errClosedDevice = errors.New("Closed device")
+var errDisconnect = errors.New("device disconnected during action")
+var errClosedDevice = errors.New("closed device")

--- a/usb/hidapi.go
+++ b/usb/hidapi.go
@@ -154,7 +154,7 @@ func detectPrepend(dev *usbhid.HidDevice) (bool, error) {
 		return false, nil
 	}
 
-	return false, errors.New("Unknown HID version")
+	return false, errors.New("unknown HID version")
 }
 
 func (d *HID) readWrite(buf []byte, read bool) (int, error) {


### PR DESCRIPTION
From https://github.com/golang/go/wiki/CodeReviewComments#error-strings :

> Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context. That is, use fmt.Errorf("something bad") not fmt.Errorf("Something bad"), so that log.Print("Reading %s: %v", filename, err) formats without a spurious capital letter mid-message. This does not apply to logging, which is implicitly line-oriented and not combined inside other messages.

