### PR TITLE
Fixed a "go vet" problem: +build comment ...

### DIFF
--- a/usb/lowlevel/libusb.go
+++ b/usb/lowlevel/libusb.go
@@ -1,3 +1,5 @@
+// +build linux,cgo darwin,!ios,cgo windows,cgo
+
 //-----------------------------------------------------------------------------
 /*
 
@@ -12,8 +14,6 @@ Copyright (c) 2017 Jason T. Harris
 package lowlevel
 
 /*
-// +build linux,cgo darwin,!ios,cgo windows,cgo
-
 #include "./c/libusb/libusb.h"
 
 // When a C struct ends with a zero-sized field, but the struct itself is not zero-sized,


### PR DESCRIPTION
A repeat of the PR to `github.com/trezor/usbhid` (which was recently deleted)

```
$ go vet ./...
# github.com/trezor/trezord-go/usb/lowlevel
/tmp/go-build237755967/b116/libusb.cgo1.go:18: +build comment must appear before package clause and be followed by a blank line
```