### PR TITLE
windows: add setupapidevlog to log

### DIFF
--- a/server/status/devcon.go
+++ b/server/status/devcon.go
@@ -347,3 +347,20 @@ func libwdiReinstallLog() (string, error) {
 	all := "libwdi reinstall log:\n" + contentStr + "\n"
 	return all, nil
 }
+
+func setupAPIDevLog() (string, error) {
+	sysroot := os.Getenv("SystemRoot")
+	folder := sysroot + "\\inf"
+	file := folder + "\\SetupAPI.dev.log"
+	content, err := ioutil.ReadFile(file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+
+	contentStr := strings.Replace(string(content), "\r\n", "\n", -1)
+	all := "setupapi device log:\n" + contentStr + "\n"
+	return all, nil
+}

--- a/server/status/devcon_shim.go
+++ b/server/status/devcon_shim.go
@@ -28,3 +28,7 @@ func isWindows() bool {
 func libwdiReinstallLog() (string, error) {
 	return "", nil
 }
+
+func setupAPIDevLog() (string, error) {
+	return "", nil
+}

--- a/server/status/status.go
+++ b/server/status/status.go
@@ -85,7 +85,15 @@ func (s *status) statusGzip(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	start := s.version + "\n" + msinfo + "\n" + devconLog + devconLogD + "\n" + libwdi
+	s.Log("getting setupapi")
+	setupapi, err := setupAPIDevLog()
+	if err != nil {
+		s.Log("setupapi err " + err.Error())
+		respondError(w, err)
+		return
+	}
+
+	start := s.version + "\n" + msinfo + "\n" + devconLog + devconLogD + "\n" + libwdi + setupapi
 
 	gzip, err := s.longMemoryWriter.Gzip(start)
 	if err != nil {


### PR DESCRIPTION
Setupapi dev log is very powerful for letting us debug device driver issues for Windows 7, for example, why are HP BIDI drivers preferred from our drivers.