### PR TITLE
libwdi: Add timeout to installer

### DIFF
--- a/release/windows/trezord.nsis
+++ b/release/windows/trezord.nsis
@@ -158,8 +158,8 @@ SectionEnd
 Section "Install drivers"
   ${If} ${IsWin7}
   DetailPrint "Installing drivers"
-  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C0 --progressbar=$HWNDPARENT > "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
-  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C1 --iid 0 --progressbar=$HWNDPARENT >> "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
+  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C0 --progressbar=$HWNDPARENT --timeout 120000 > "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
+  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C1 --iid 0 --progressbar=$HWNDPARENT --timeout 120000 >> "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
   ${EndIf}
   nsExec::ExecToLog '"$INSTDIR\devcon.exe" rescan'
 SectionEnd


### PR DESCRIPTION
Because of the installation of the first driver, the second driver never happened and immediately crashed in rare cases. (I found this issue only because of the new libwdi install logs.)

This adds a timeout of 2 minutes. (It should be enough - looking at the logs from the faulty system, the installation takes about 15 seconds).

This should hopefully fix the remaining driver issues.