### PR TITLE
windows libusb: show only winusb devices

### DIFF
--- a/usb/lowlevel/c/libusb/libusbi.h
+++ b/usb/lowlevel/c/libusb/libusbi.h
@@ -380,6 +380,8 @@ struct libusb_device {
 	struct list_head list;
 	unsigned long session_data;
 
+	int has_winusb_driver;
+
 	struct libusb_device_descriptor device_descriptor;
 	int attached;
 

--- a/usb/lowlevel/c/libusb/libusbi.h
+++ b/usb/lowlevel/c/libusb/libusbi.h
@@ -74,9 +74,6 @@ extern "C" {
 #define ARRAYSIZE(array) (sizeof(array) / sizeof(array[0]))
 #endif
 
-struct list_head {
-	struct list_head *prev, *next;
-};
 
 /* Get an entry from the list
  *  ptr - the address of this list_head element in "type"

--- a/usb/lowlevel/c/libusb/os/threads_windows.h
+++ b/usb/lowlevel/c/libusb/os/threads_windows.h
@@ -26,13 +26,6 @@
 
 #define usbi_mutex_t		HANDLE
 
-typedef struct usbi_cond {
-	// Every time a thread touches the CV, it winds up in one of these lists.
-	//   It stays there until the CV is destroyed, even if the thread terminates.
-	struct list_head waiters;
-	struct list_head not_waiting;
-} usbi_cond_t;
-
 // We *were* getting timespec from pthread.h:
 #if (!defined(HAVE_STRUCT_TIMESPEC) && !defined(_TIMESPEC_DEFINED))
 #define HAVE_STRUCT_TIMESPEC 1

--- a/usb/lowlevel/c/libusb/os/windows_winusb.c
+++ b/usb/lowlevel/c/libusb/os/windows_winusb.c
@@ -1103,6 +1103,8 @@ static int init_device(struct libusb_device *dev, struct libusb_device *parent_d
 		dev->device_address = 1; // root hubs are set to use device number 1
 		force_hcd_device_descriptor(dev);
 	}
+	
+	dev->has_winusb_driver = 0;
 
 	usbi_sanitize_device(dev);
 
@@ -1177,6 +1179,10 @@ static int set_composite_interface(struct libusb_context *ctx, struct libusb_dev
 	if (priv->apib->id != USB_API_COMPOSITE) {
 		usbi_err(ctx, "program assertion failed: '%s' is not composite", device_id);
 		return LIBUSB_ERROR_NO_DEVICE;
+	}
+
+	if (api == USB_API_WINUSBX) {
+		dev->has_winusb_driver = 1;
 	}
 
 	// Because MI_## are not necessarily in sequential order (some composite
@@ -1538,6 +1544,8 @@ static int windows_get_device_list(struct libusb_context *ctx, struct discovered
 
 					priv->hid->nb_interfaces = 0;
 					break;
+				case USB_API_WINUSBX:
+					dev->has_winusb_driver = 1;
 				default:
 					// For other devices, the first interface is the same as the device
 					priv->usb_interface[0].path = _strdup(priv->path);
@@ -1552,6 +1560,7 @@ static int windows_get_device_list(struct libusb_context *ctx, struct discovered
 				}
 				break;
 			case GEN_PASS:
+				usbi_info(ctx, "Will init device");
 				r = init_device(dev, parent_dev, (uint8_t)port_nr, dev_id_path, dev_info_data.DevInst);
 				if (r == LIBUSB_SUCCESS) {
 					// Append device to the list of discovered devices

--- a/usb/lowlevel/hid.go
+++ b/usb/lowlevel/hid.go
@@ -11,6 +11,10 @@
 package lowlevel
 
 /*
+struct list_head {
+	struct list_head *prev, *next;
+};
+
 extern void goLog(const char *s);
 
 #define ENABLE_LOGGING 1
@@ -44,11 +48,20 @@ extern void goLog(const char *s);
 	#define HARDCODED_HIDAPI_DEVICE_FILTER "vid_534c"
 	#define HARDCODED_LIBUSB_DEVICE_FILTER "VID_1209"
 
+
+  typedef struct usbi_cond {
+    struct list_head waiters;
+    struct list_head not_waiting;
+  } usbi_cond_t;
+
+
 	#include <oledlg.h>
 
 	#include "os/poll_windows.c"
 	#include "os/threads_windows.c"
 #endif
+
+#include "libusbi.h"
 
 #include "core.c"
 #include "descriptor.c"

--- a/usb/lowlevel/libusb.go
+++ b/usb/lowlevel/libusb.go
@@ -14,7 +14,29 @@ Copyright (c) 2017 Jason T. Harris
 package lowlevel
 
 /*
+struct list_head {
+	struct list_head *prev, *next;
+};
+
 #include "./c/libusb/libusb.h"
+
+#ifdef OS_WINDOWS
+  #define usbi_mutex_t              HANDLE
+  #define usbi_tls_key_t                      DWORD
+
+  typedef struct usbi_cond {
+    struct list_head waiters;
+    struct list_head not_waiting;
+  } usbi_cond_t;
+
+  #define usbi_mutex_static_t       volatile LONG
+#else
+  #define usbi_mutex_t              pthread_mutex_t
+  #define usbi_tls_key_t                      pthread_key_t
+  #define usbi_cond_t                 pthread_cond_t
+  #define usbi_mutex_static_t         pthread_mutex_t
+#endif
+
 #include "./c/libusb/libusbi.h"
 
 // When a C struct ends with a zero-sized field, but the struct itself is not zero-sized,

--- a/usb/lowlevel/libusb.go
+++ b/usb/lowlevel/libusb.go
@@ -15,6 +15,7 @@ package lowlevel
 
 /*
 #include "./c/libusb/libusb.h"
+#include "./c/libusb/libusbi.h"
 
 // When a C struct ends with a zero-sized field, but the struct itself is not zero-sized,
 // Go code can no longer refer to the zero-sized field. Any such references will have to be rewritten.
@@ -1099,6 +1100,11 @@ func Strerror(errcode int) string {
 
 //-----------------------------------------------------------------------------
 // USB descriptors
+
+func Device_Has_Winusb(dev Device) bool {
+	cHas := int(dev.has_winusb_driver)
+	return cHas == 1
+}
 
 func Get_Device_Descriptor(dev Device) (*Device_Descriptor, error) {
 	var desc C.struct_libusb_device_descriptor

--- a/usb/webusb.go
+++ b/usb/webusb.go
@@ -3,6 +3,7 @@ package usb
 import (
 	"encoding/hex"
 	"fmt"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -196,7 +197,16 @@ func (b *WebUSB) connect(dev lowlevel.Device) (*WUD, error) {
 	}, nil
 }
 
+func isWindows() bool {
+	return strings.HasPrefix(runtime.GOOS, "windows")
+}
+
 func (b *WebUSB) match(dev lowlevel.Device) bool {
+	if isWindows() {
+		if !lowlevel.Device_Has_Winusb(dev) {
+			return false
+		}
+	}
 	dd, err := lowlevel.Get_Device_Descriptor(dev)
 	if err != nil {
 		b.mw.Println("webusb - match - error getting descriptor -" + err.Error())


### PR DESCRIPTION
Libusb lists all devices, even those without drivers.

What can happen is that a user can open web wallet, connect a new device, and while the winusb driver is installing, the device is shown to wallet, which tries to immediately connect to it and errors. User sees libusb error and thinks something is broken (while reconnecting device would have actually helped).

So what we need to do is to exclude devices without winusb drivers in device listing.

I was too afraid to change the device listing in os/windows_winusb.c to exclude it directly there - because I was afraid of a memory leak (the memory is manually managed for the device objects).

Instead, I did a dirtier solution - I have added a field to the device struct that is by default 0 on both composite devices and "single" devices, but is 1 if either the "single" device is winusb or if any of the sub-devices on the composite device is winusb. This field is then looked at in device listing *in golang layers*.

This could MAYBE cause an issue some day in the future if we have MORE winusb endpoints, and this will get set as 1 on the first endpoint, even when the other endpoints won't be inited. However this would cause more havoc probably anyway in the golang layers, and also probably in webusb in chrome. So, it is not really an issue I guess

I can confirm this fixes the issue on my windows 7 - the device is not displayed in wallet while it the device is installed, it appears in wallet immediately after the installation is done.

(PS: I have no idea how did Chromium solve this with their heavily patched libusb fork... because they probably have the same issue.)