### PR TITLE
windows: Less intrusive winusb check

### DIFF
--- a/usb/lowlevel/c/libusb/descriptor.c
+++ b/usb/lowlevel/c/libusb/descriptor.c
@@ -534,7 +534,7 @@ int usbi_device_cache_descriptor(libusb_device *dev)
  * This is a non-blocking function; the device descriptor is cached in memory.
  *
  * Note since libusb-1.0.16, \ref LIBUSB_API_VERSION >= 0x01000102, this
- * function always succeeds.
+ * function always succeeds. (Not true in trezord fork on windows.)
  *
  * \param dev the device
  * \param desc output location for the descriptor data
@@ -546,6 +546,16 @@ int API_EXPORTED libusb_get_device_descriptor(libusb_device *dev,
 	usbi_dbg("");
 	memcpy((unsigned char *) desc, (unsigned char *) &dev->device_descriptor,
 	       sizeof (dev->device_descriptor));
+
+	#ifdef OS_WINDOWS
+	// hack for filtering out non-winusb devices in trezord
+	// (note that in trezord layer, throwing error here does NOT throw error up the chain,
+	//  it just ignores the device)
+	if (!dev->has_winusb_driver) {
+		usbi_dbg("winUSB not detected, return error");
+		return LIBUSB_ERROR_OTHER;
+	}
+	#endif
 	return 0;
 }
 

--- a/usb/lowlevel/c/libusb/libusbi.h
+++ b/usb/lowlevel/c/libusb/libusbi.h
@@ -74,6 +74,9 @@ extern "C" {
 #define ARRAYSIZE(array) (sizeof(array) / sizeof(array[0]))
 #endif
 
+struct list_head {
+	struct list_head *prev, *next;
+};
 
 /* Get an entry from the list
  *  ptr - the address of this list_head element in "type"
@@ -377,7 +380,9 @@ struct libusb_device {
 	struct list_head list;
 	unsigned long session_data;
 
+	#ifdef OS_WINDOWS
 	int has_winusb_driver;
+	#endif
 
 	struct libusb_device_descriptor device_descriptor;
 	int attached;

--- a/usb/lowlevel/c/libusb/os/threads_windows.h
+++ b/usb/lowlevel/c/libusb/os/threads_windows.h
@@ -26,6 +26,13 @@
 
 #define usbi_mutex_t		HANDLE
 
+typedef struct usbi_cond {
+	// Every time a thread touches the CV, it winds up in one of these lists.
+	//   It stays there until the CV is destroyed, even if the thread terminates.
+	struct list_head waiters;
+	struct list_head not_waiting;
+} usbi_cond_t;
+
 // We *were* getting timespec from pthread.h:
 #if (!defined(HAVE_STRUCT_TIMESPEC) && !defined(_TIMESPEC_DEFINED))
 #define HAVE_STRUCT_TIMESPEC 1

--- a/usb/lowlevel/hid.go
+++ b/usb/lowlevel/hid.go
@@ -11,10 +11,6 @@
 package lowlevel
 
 /*
-struct list_head {
-	struct list_head *prev, *next;
-};
-
 extern void goLog(const char *s);
 
 #define ENABLE_LOGGING 1
@@ -48,20 +44,11 @@ extern void goLog(const char *s);
 	#define HARDCODED_HIDAPI_DEVICE_FILTER "vid_534c"
 	#define HARDCODED_LIBUSB_DEVICE_FILTER "VID_1209"
 
-
-  typedef struct usbi_cond {
-    struct list_head waiters;
-    struct list_head not_waiting;
-  } usbi_cond_t;
-
-
 	#include <oledlg.h>
 
 	#include "os/poll_windows.c"
 	#include "os/threads_windows.c"
 #endif
-
-#include "libusbi.h"
 
 #include "core.c"
 #include "descriptor.c"

--- a/usb/lowlevel/libusb.go
+++ b/usb/lowlevel/libusb.go
@@ -14,30 +14,7 @@ Copyright (c) 2017 Jason T. Harris
 package lowlevel
 
 /*
-struct list_head {
-	struct list_head *prev, *next;
-};
-
 #include "./c/libusb/libusb.h"
-
-#ifdef OS_WINDOWS
-  #define usbi_mutex_t              HANDLE
-  #define usbi_tls_key_t                      DWORD
-
-  typedef struct usbi_cond {
-    struct list_head waiters;
-    struct list_head not_waiting;
-  } usbi_cond_t;
-
-  #define usbi_mutex_static_t       volatile LONG
-#else
-  #define usbi_mutex_t              pthread_mutex_t
-  #define usbi_tls_key_t                      pthread_key_t
-  #define usbi_cond_t                 pthread_cond_t
-  #define usbi_mutex_static_t         pthread_mutex_t
-#endif
-
-#include "./c/libusb/libusbi.h"
 
 // When a C struct ends with a zero-sized field, but the struct itself is not zero-sized,
 // Go code can no longer refer to the zero-sized field. Any such references will have to be rewritten.
@@ -1122,11 +1099,6 @@ func Strerror(errcode int) string {
 
 //-----------------------------------------------------------------------------
 // USB descriptors
-
-func Device_Has_Winusb(dev Device) bool {
-	cHas := int(dev.has_winusb_driver)
-	return cHas == 1
-}
 
 func Get_Device_Descriptor(dev Device) (*Device_Descriptor, error) {
 	var desc C.struct_libusb_device_descriptor

--- a/usb/webusb.go
+++ b/usb/webusb.go
@@ -3,7 +3,6 @@ package usb
 import (
 	"encoding/hex"
 	"fmt"
-	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -197,16 +196,7 @@ func (b *WebUSB) connect(dev lowlevel.Device) (*WUD, error) {
 	}, nil
 }
 
-func isWindows() bool {
-	return strings.HasPrefix(runtime.GOOS, "windows")
-}
-
 func (b *WebUSB) match(dev lowlevel.Device) bool {
-	if isWindows() {
-		if !lowlevel.Device_Has_Winusb(dev) {
-			return false
-		}
-	}
 	dd, err := lowlevel.Get_Device_Descriptor(dev)
 	if err != nil {
 		b.mw.Println("webusb - match - error getting descriptor -" + err.Error())


### PR DESCRIPTION
"Less intrusive" in that the libusb headers are not changed and included in go layer,
so other OS can use the default, system-wide one.

This returns the headers in the go files to the state before #90 

Fixes https://github.com/trezor/trezord-go/issues/94