### PR TITLE
usb: read libusb error_pipe as disconnect error

### DIFF
--- a/usb/webusb.go
+++ b/usb/webusb.go
@@ -317,7 +317,11 @@ func (d *WUD) readWrite(buf []byte, endpoint uint8) (int, error) {
 		if err != nil {
 			d.mw.Println(fmt.Sprintf("webusb - rw - error seen - %s", err.Error()))
 			if err.Error() == lowlevel.Error_Name(int(lowlevel.ERROR_IO)) ||
-				err.Error() == lowlevel.Error_Name(int(lowlevel.ERROR_NO_DEVICE)) {
+				err.Error() == lowlevel.Error_Name(int(lowlevel.ERROR_NO_DEVICE)) ||
+				err.Error() == lowlevel.Error_Name(int(lowlevel.ERROR_PIPE)) {
+				// according to libusb docs, disconnecting device should cause only
+				// LIBUSB_ERROR_NO_DEVICE error, but in real life, it causes also
+				// LIBUSB_ERROR_IO and LIBUSB_ERROR_PIPE
 				d.mw.Println("webusb - rw - device probably disconnected")
 				return 0, errDisconnect
 			}


### PR DESCRIPTION
I *think* this happens only on Linux when disconnecting device while communication is going on.

Tested on Linux, the error is now more readable.