### PR TITLE
usb: Do not finish read queue on disconnected

### DIFF
--- a/usb/hidapi.go
+++ b/usb/hidapi.go
@@ -111,7 +111,7 @@ type HID struct {
 	mw *memorywriter.MemoryWriter
 }
 
-func (d *HID) Close() error {
+func (d *HID) Close(disconnected bool) error {
 
 	d.mw.Println("hidapi - close - storing d.closed")
 	atomic.StoreInt32(&d.closed, 1)

--- a/usb/udp.go
+++ b/usb/udp.go
@@ -136,7 +136,7 @@ type UDPDevice struct {
 	closed int32 // atomic
 }
 
-func (d *UDPDevice) Close() error {
+func (d *UDPDevice) Close(disconnected bool) error {
 	atomic.StoreInt32(&d.closed, 1)
 	return nil
 }

--- a/usb/webusb.go
+++ b/usb/webusb.go
@@ -294,12 +294,16 @@ type WUD struct {
 	mw *memorywriter.MemoryWriter
 }
 
-func (d *WUD) Close() error {
+func (d *WUD) Close(disconnected bool) error {
 	d.mw.Println("webusb - close - storing d.closed")
 	atomic.StoreInt32(&d.closed, 1)
 
-	d.mw.Println("webusb - close - finishing read queue")
-	d.finishReadQueue()
+	// reading recently disconnected device sometimes causes weird issues
+	// => if we *know* it is disconnected, don't finish read queue
+	if !disconnected {
+		d.mw.Println("webusb - close - finishing read queue")
+		d.finishReadQueue()
+	}
 
 	d.mw.Println("webusb - close - wait for transferMutex lock")
 	d.transferMutex.Lock()


### PR DESCRIPTION
"Finishing reading queue" is necessary only because sometimes the handle is closed before the device sends all the USB packets, which happens only when one app "steals" device from another.

It is never necessary on disconnected devices; on the contrary, it sometimes causes issues. (On freebsd, for example.)

This requires a slight change in the device interface.