### PR TITLE
windows: Remove wait for pending install

### DIFF
--- a/release/windows/libwdi/libwdi/libwdi.c
+++ b/release/windows/libwdi/libwdi/libwdi.c
@@ -1449,7 +1449,6 @@ static int process_message(char* buffer, DWORD size)
 static int install_driver_internal(void* arglist)
 {
 	PF_DECL_LIBRARY(SetupAPI);
-	PF_TYPE_DECL(WINAPI, DWORD, CMP_WaitNoPendingInstallEvents, (DWORD));
 	struct install_driver_params* params = (struct install_driver_params*)arglist;
 	SHELLEXECUTEINFOA shExecInfo;
 	STARTUPINFOA si;
@@ -1476,7 +1475,6 @@ static int install_driver_internal(void* arglist)
 
 	PF_LOAD_LIBRARY(SetupAPI);
 	r = WDI_ERROR_RESOURCE;
-	PF_INIT_OR_OUT(CMP_WaitNoPendingInstallEvents, SetupAPI);
 
 	current_device = params->device_info;
 	filter_driver = FALSE;
@@ -1497,17 +1495,6 @@ static int install_driver_internal(void* arglist)
 		wdi_err("one of the required parameter is NULL");
 		r = WDI_ERROR_INVALID_PARAM;
 		goto out;
-	}
-
-	// Detect if another installation is in process
-	if ((params->options != NULL) && (pfCMP_WaitNoPendingInstallEvents != NULL)) {
-		if (pfCMP_WaitNoPendingInstallEvents(params->options->pending_install_timeout) == WAIT_TIMEOUT) {
-			wdi_warn("timeout expired while waiting for another pending installation - aborting");
-			r = WDI_ERROR_PENDING_INSTALLATION;
-			goto out;
-		}
-	} else {
-		wdi_dbg("CMP_WaitNoPendingInstallEvents not available");
 	}
 
 	// Detect whether if we should run the 64 bit installer, without

--- a/release/windows/trezord.nsis
+++ b/release/windows/trezord.nsis
@@ -171,8 +171,8 @@ SectionEnd
 Section "Install drivers"
   ${If} ${IsWin7}
   DetailPrint "Installing drivers"
-  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C0 --progressbar=$HWNDPARENT --timeout 120000 > "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
-  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C1 --iid 0 --progressbar=$HWNDPARENT --timeout 120000 >> "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
+  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C0 --progressbar=$HWNDPARENT > "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
+  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C1 --iid 0 --progressbar=$HWNDPARENT >> "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
   ${EndIf}
   nsExec::ExecToLog '"$INSTDIR\devcon.exe" rescan'
 SectionEnd


### PR DESCRIPTION
Right now, we wait for all other pending installation to finish before we start installing the driver, and if we time out, we don't install the driver.

I think it causes more issues than it solves. Let's try removing the wait, what happens.

See also discussion here

https://github.com/pbatard/libwdi/pull/140