### PR TITLE
macos: Don't call ClearPipeStallBothEnds at timeout

### DIFF
--- a/usb/lowlevel/c/libusb/os/darwin_usb.c
+++ b/usb/lowlevel/c/libusb/os/darwin_usb.c
@@ -1849,7 +1849,10 @@ static int darwin_abort_transfers (struct usbi_transfer *itransfer) {
   usbi_dbg ("calling clear pipe stall to clear the data toggle bit");
 
   /* newer versions of darwin support clearing additional bits on the device's endpoint */
-  kresult = (*(cInterface->interface))->ClearPipeStallBothEnds(cInterface->interface, pipeRef);
+  // commented out in trezord fork, since it caused strange hangs on Trezor 1
+  // however, if we also comment out AbortPipe few lines earlier, it causes strange hangs on Trezor T
+  // kresult = (*(cInterface->interface))->ClearPipeStallBothEnds(cInterface->interface, pipeRef);
+  kresult = kIOReturnSuccess;
 
   return darwin_to_libusb (kresult);
 }


### PR DESCRIPTION
We noticed strange behavior on macOS with bridge/webusb, I think I sort of found what is going on.

**None** of the low-level (meaning the OS) APIs for interrupt transfers (macOS, linux, windows) have built-in timeouts with interrupt reads.

What happens in libusb instead (if we use timeouts) is:

* libusb calls low-level API for interrupt read, which has no build-in timeout, and saves the timeout in libusb struct
* then, and **this is important part**, after the time-out is over, it explicitly calls `libusb_cancel_transfer`, which then calls OS specific call (in the macOS example, it boils down to `darwin_abort_transfers`)

We use the interrupt transfers with timeouts, so we can more easily do "session stealing" with mutexes.

The problem is the transfer aborting is sending some USB control messages, and those control messages seem to sometimes confuse Trezor and somehow stop the communication (but only in some cases). 

On macOS, libusb calls ClearPipeStallBothEnds. There is some documentation [here](https://developer.apple.com/documentation/iokit/iousbinterfaceinterface190/1559241-clearpipestallbothends?language=objc) - however, that seems to be outdated (very old API version), but the new [API has 0 documentation](https://developer.apple.com/documentation/iokit/iousbinterfaceinterface700/1559337-clearpipestallbothends?language=objc) (thanks Apple). This causes problems in Trezor 1 bootloader WebUSB communication - every time ClearPipeStallBothEnds is called, T1 webusb bootloader stops responding and all other calls result in error. (It does not happen with T1 firmware or TT bootloader)

When I replaced ClearPipeStallBothEnds with ClearPipeStall, T1 started working (so the docs are wrong and they are not equivalent). However, Trezor T bootloader suddenly stopped working. When I commented out the call completely (as in the PR), it started working on both Trezor T and Trezor 1.

When I, for interest, commented out the whole function - that is, I also commented out `AbortPipe` - the T1 still kept working, but TT bootloader stopped working.

Unfortunately, I cannot debug bootloaders, so I don't know what is wrong. However this fixes the problems.

I have no idea why Chrome keeps working, when they don't have this function changed. They seem to be using [old libusb version of darwin_usb.c](https://github.com/chromium/chromium/blob/7205a8565740840b4445d1d426a1d4412fc6e73e/third_party/libusb/src/libusb/os/darwin_usb.c) / [.h](https://github.com/chromium/chromium/blob/7205a8565740840b4445d1d426a1d4412fc6e73e/third_party/libusb/src/libusb/os/darwin_usb.h), but this old version is doing the same problems when I try to use it in trezord-go. But Chrome is using the libusb functions slightly differently and are using the asynchronoys callback-based APIs themselves, while we are just using the synchronous wrappers (from libusb/sync.c), and the chrome code is hard to navigate for me. They also seem to use much shorter timeouts than us (10 ms), but when we try these short timeouts, TT communication breaks, so I don't know.

-------

What seems to fix the problem better is *not to use timeouts at all*. When I removed the timeouts, bridge started working on both T1 and TT. *However*, we would need to rewrite the code significantly, because the synch code does not support cancelling transfers.

-----

So basically our three options are:

* use this PR and hope that nothing breaks
* rewrite our use of sync functions to async functions (hard, possible)
* add some possibility to cancel sync transfers to sync.c (difficult not to cause some C deadlock/memory leak)