### PR TITLE
libusb: Add cancel to sync.c, don't use timeouts

### DIFF
--- a/usb/lowlevel/c/libusb/libusb.h
+++ b/usb/lowlevel/c/libusb/libusb.h
@@ -1745,6 +1745,9 @@ static inline unsigned char *libusb_get_iso_packet_buffer_simple(
 
 /* sync I/O */
 
+
+void LIBUSB_CALL libusb_cancel_sync_transfers_on_device(struct libusb_device_handle *dev_handle);
+
 int LIBUSB_CALL libusb_control_transfer(libusb_device_handle *dev_handle,
 	uint8_t request_type, uint8_t bRequest, uint16_t wValue, uint16_t wIndex,
 	unsigned char *data, uint16_t wLength, unsigned int timeout);

--- a/usb/lowlevel/c/libusb/sync.c
+++ b/usb/lowlevel/c/libusb/sync.c
@@ -163,6 +163,75 @@ int API_EXPORTED libusb_control_transfer(libusb_device_handle *dev_handle,
 	return r;
 }
 
+// ============= TREZORD LIBUSB CODE ============
+
+// libusb does not have the option to cancel transfers, made through sync API
+// however, we did not want to rewrite everything into async API and
+// basically re-implement sync.c in go
+// -> so I added a function that kills running transfers on a device
+//
+// It works because I know there is always only 1 transfer running on 1 device,
+// because of mutexes in the golang code
+
+#define MAX_SAVED_TRANSFERS 50
+struct running_transfer {
+	struct libusb_device_handle *dev_handle;
+	struct libusb_transfer *transfer;
+};
+static struct running_transfer running_transfers[MAX_SAVED_TRANSFERS];
+// it will fail with >50 transfers, but since we limit 1 trezor to 1 transfer,
+// that would mean 50 concurrent connected trezors
+// - and also it doesn't fail that terribly, it just doesn't cancel the transfers
+
+static usbi_mutex_static_t running_transfers_lock = USBI_MUTEX_INITIALIZER;
+
+static void save_running_transfer(struct libusb_device_handle *dev_handle, struct libusb_transfer *transfer) {
+	usbi_dbg("wait for lock");
+	usbi_mutex_static_lock(&running_transfers_lock);
+	usbi_dbg("wait for lock finished");
+	int i = 0;
+	for (i = 0; i < MAX_SAVED_TRANSFERS; i++) {
+		if (running_transfers[i].dev_handle == NULL) {
+			usbi_dbg("saved at %d", i);
+			running_transfers[i].dev_handle = dev_handle;
+			running_transfers[i].transfer = transfer;
+			usbi_mutex_static_unlock(&running_transfers_lock);
+			return;
+		}
+	}
+	usbi_dbg("not saved");
+	usbi_mutex_static_unlock(&running_transfers_lock);
+}
+
+static struct libusb_transfer* get_and_remove_running_transfer(struct libusb_device_handle *dev_handle) {
+	usbi_dbg("wait for lock");
+	usbi_mutex_static_lock(&running_transfers_lock);
+	usbi_dbg("wait for lock finished");
+	int i = 0;
+	for (i = 0; i < MAX_SAVED_TRANSFERS; i++) {
+		if (running_transfers[i].dev_handle == dev_handle) {
+			usbi_dbg("got at %d", i);
+			struct libusb_transfer* res = running_transfers[i].transfer;
+			running_transfers[i].dev_handle = NULL;
+			running_transfers[i].transfer = NULL;
+			usbi_mutex_static_unlock(&running_transfers_lock);
+			return res;
+		}
+	}
+	usbi_dbg("did not get any");
+	usbi_mutex_static_unlock(&running_transfers_lock);
+	return NULL;
+}
+
+void API_EXPORTED libusb_cancel_sync_transfers_on_device(struct libusb_device_handle *dev_handle) {
+	struct libusb_transfer* t = get_and_remove_running_transfer(dev_handle);
+	if (t != NULL){
+		libusb_cancel_transfer(t);
+	}
+}
+
+// ============= TREZORD LIBUSB CODE END ========
+
 static int do_sync_bulk_transfer(struct libusb_device_handle *dev_handle,
 	unsigned char endpoint, unsigned char *buffer, int length,
 	int *transferred, unsigned int timeout, unsigned char type)
@@ -195,8 +264,15 @@ static int do_sync_bulk_transfer(struct libusb_device_handle *dev_handle,
 		return r;
 	}
 
-	usbi_dbg("wait for completion");
+	usbi_dbg("save_running_transfer");
+	save_running_transfer(dev_handle, transfer);
+
+	usbi_dbg("sync_transfer_wait_for_completion");
 	sync_transfer_wait_for_completion(transfer);
+
+	// removing the transfer from the saved structure
+	usbi_dbg("get_and_remove_running_transfer");
+	get_and_remove_running_transfer(dev_handle);
 
 	if (transferred)
 		*transferred = transfer->actual_length;

--- a/usb/lowlevel/libusb.go
+++ b/usb/lowlevel/libusb.go
@@ -1370,4 +1370,9 @@ func Interrupt_Transfer(hdl Device_Handle, endpoint uint8, data []byte, timeout 
 	return data[:int(transferred)], nil
 }
 
+// libusb_cancel_sync_transfers_on_device(struct libusb_device_handle *dev_handle) {
+func Cancel_Sync_Transfers_On_Device(hdl Device_Handle) {
+	C.libusb_cancel_sync_transfers_on_device(hdl)
+}
+
 //-----------------------------------------------------------------------------

--- a/usb/lowlevel/libusb.go
+++ b/usb/lowlevel/libusb.go
@@ -20,6 +20,10 @@ package lowlevel
 #include "./c/libusb/libusb.h"
 #else
 #include <libusb.h>
+
+// "fake" function so freebsd builds
+void libusb_cancel_sync_transfers_on_device(struct libusb_device_handle *dev_handle) {
+}
 #endif
 
 // When a C struct ends with a zero-sized field, but the struct itself is not zero-sized,


### PR DESCRIPTION
The main reason why we used interrupt with timeouts is that we cannot cancel transfers, using the libusb synchronnous API.

However, the repeated timeouts cause issues with the bootloader for unknown reasons.

Instead of using timeouts, I added a function to cancel transfers to synch libusb API. Then we can safely remove the timeouts from the code, since we cancel the calls manually. (We cannot remove them completely - we still use them for finishing the read queue.)

What I did not know before is that using libusb close on a device with pending synch transfers **does not cancel the pending transfers** - and the transfers then hang forever! (Also, libusb device close is a non-blocking function.)

---

This is a little complex, but the other option would be to basically rewrite sync.c into go.

Unfortunately this probably breaks FreeBSD again, since we add API to libusb.

--- 

This is a different approach to solving the timeout problems than this PR - https://github.com/trezor/trezord-go/pull/103 - and probably better. But it breaks compatibility with "out of the box" libusb.