### PR TITLE
Return libwdi timeout & make it larger

### DIFF
--- a/release/windows/trezord.nsis
+++ b/release/windows/trezord.nsis
@@ -171,8 +171,9 @@ SectionEnd
 Section "Install drivers"
   ${If} ${IsWin7}
   DetailPrint "Installing drivers"
-  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C0 --progressbar=$HWNDPARENT --timeout 120000 > "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
-  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C1 --iid 0 --progressbar=$HWNDPARENT --timeout 120000 >> "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
+  ; 900 000 milliseconds is 15 minutes
+  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C0 --progressbar=$HWNDPARENT --timeout 900000 > "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
+  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C1 --iid 0 --progressbar=$HWNDPARENT --timeout 900000 >> "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
   ${EndIf}
   nsExec::ExecToLog '"$INSTDIR\devcon.exe" rescan'
 SectionEnd

--- a/release/windows/trezord.nsis
+++ b/release/windows/trezord.nsis
@@ -171,8 +171,8 @@ SectionEnd
 Section "Install drivers"
   ${If} ${IsWin7}
   DetailPrint "Installing drivers"
-  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C0 --progressbar=$HWNDPARENT > "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
-  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C1 --iid 0 --progressbar=$HWNDPARENT >> "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
+  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C0 --progressbar=$HWNDPARENT --timeout 120000 > "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
+  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C1 --iid 0 --progressbar=$HWNDPARENT --timeout 120000 >> "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
   ${EndIf}
   nsExec::ExecToLog '"$INSTDIR\devcon.exe" rescan'
 SectionEnd


### PR DESCRIPTION
The libwdi installer seems to timeout on strange places, waiting for syslog access, if the timeout is removed

So I reverted https://github.com/trezor/trezord-go/pull/100 and instead made the timeout larger - 15 minutes

That does NOT mean it will always take 15 minutes to install bridge of course - it will wait at most for 15 minutes for installing the driver, if the system is doing something else, and then it will give up