### PR TITLE
Cleanup of OS-specific (freebsd) code

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -25,15 +25,12 @@ type Server struct {
 }
 
 func New(
-	bus core.USBBus,
+	c *core.Core,
 	stderrWriter io.Writer,
 	shortWriter *memorywriter.MemoryWriter,
 	longWriter *memorywriter.MemoryWriter,
 	version string,
 ) (*Server, error) {
-
-	c := core.New(bus, longWriter)
-
 	longWriter.Println("http - starting")
 
 	https := &http.Server{

--- a/trezord.go
+++ b/trezord.go
@@ -42,11 +42,11 @@ func (i *udpPorts) Set(value string) error {
 
 func initUsb(init bool, wr *memorywriter.MemoryWriter, sl *log.Logger) []core.USBBus {
 	if init {
-		wr.Println("Initing webusb")
+		wr.Println("Initing libusb")
 
-		w, err := usb.InitWebUSB(wr, useOnlyLibusb(), allowCancel())
+		w, err := usb.InitLibUSB(wr, useOnlyLibusb(), allowCancel())
 		if err != nil {
-			sl.Fatalf("webusb: %s", err)
+			sl.Fatalf("libusb: %s", err)
 		}
 		// defer w.Close()
 		// not defering - originally in main, now here, here makes no sense

--- a/trezord.go
+++ b/trezord.go
@@ -44,7 +44,7 @@ func initUsb(init bool, wr *memorywriter.MemoryWriter, sl *log.Logger) []core.US
 	if init {
 		wr.Println("Initing libusb")
 
-		w, err := usb.InitLibUSB(wr, useOnlyLibusb(), allowCancel())
+		w, err := usb.InitLibUSB(wr, useOnlyLibusb(), allowCancel(), detachKernelDriver())
 		if err != nil {
 			sl.Fatalf("libusb: %s", err)
 		}
@@ -137,4 +137,9 @@ func allowCancel() bool {
 // Does OS use libusb for HID devices?
 func useOnlyLibusb() bool {
 	return runtime.GOOS == "freebsd" || runtime.GOOS == "linux"
+}
+
+// Does OS detach kernel driver in libusb?
+func detachKernelDriver() bool {
+	return runtime.GOOS == "linux"
 }

--- a/usb/hidapi.go
+++ b/usb/hidapi.go
@@ -17,7 +17,6 @@ import (
 
 const (
 	hidapiPrefix = "hid"
-	hidIfaceNum  = 0
 	hidUsagePage = 0xFF00
 	hidTimeout   = 50
 )
@@ -90,7 +89,7 @@ func (b *HIDAPI) match(d *lowlevel.HidDeviceInfo) bool {
 	pid := d.ProductID
 	trezor1 := vid == core.VendorT1 && (pid == core.ProductT1Firmware)
 	trezor2 := vid == core.VendorT2 && (pid == core.ProductT2Firmware || pid == core.ProductT2Bootloader)
-	return (trezor1 || trezor2) && (d.Interface == hidIfaceNum || d.UsagePage == hidUsagePage)
+	return (trezor1 || trezor2) && (d.Interface == usbIfaceNum || d.UsagePage == hidUsagePage)
 }
 
 func (b *HIDAPI) identify(dev *lowlevel.HidDeviceInfo) string {

--- a/usb/lowlevel/hid.go
+++ b/usb/lowlevel/hid.go
@@ -65,6 +65,8 @@ extern void goLog(const char *s);
 	#include <libusb.h>
 #endif
 
+// linux and freebsd are including hid only that it builds;
+// it actually does not use it for listing, see trezord.go
 #ifdef OS_LINUX
 	#include "linux/hid.c"
 #elif OS_FREEBSD


### PR DESCRIPTION
I have done a small cleanup of OS-specific code.

tl;dr:

* On freebsd, do not allow session stealing, as it's too complex to do with system libusb.
* On freebsd and linux, use libusb even for the current HID trezor.
* rename webusb.go/WebUSB to libusb.go/LibUSB

---

The initial problem I was trying to solve is the 5-second timeouts still create issues on FreeBSD. 

---

To explain why do we need all this complicated machinery. For better user experience, we allow for "multitasking" - that is, applications can "steal" sessions from each other when device is in session, and that should cancel the communication. The result after "session stealing" should be a device that is capable of communication; after a session is stolen and after the stealing application calls an "initialize" message, the device should be in a fresh state and reply message with features.

Why is this done? User can have many windows with many applications open, but want to communicate with just one website on the foreground. Trezor starts to automatically communicate with some background tab - but user can steal the session from the background tab in the foreground tab (that has the app that he wants to use) and starts using trezor (and the background tab action fails, but user doesn't care about that). No background tab can "block" using trezor.

How to simulate this (there is a bug in web wallet now that does make it a little complicated :(( ):
* open trezor web wallet in one tab, clear all saved devices
* connect a device, do all the initialization dance (pin, passphrase, load accounts)
* disconnect device, click on "save", device is now saved
* connect the device again
* do some action that starts a session but doesn't immedialy end it - for example, displaying address and keep waiting
* open in another tab another web wallet
* now it should say "used in another window", but clicking on the icon next to it should end the previous session and start with a clean slate (sending of the "initialize" message here is, however, up to the website, bridge doesn't do that)

----

This is rather complicated in reality, since there are interlocking issues here.

* for reason I cannot remember - maybe this issue https://github.com/libopencm3/libopencm3/issues/668 maybe some other - we had a problem on some system with enumerating the devices while there was a transfer going on. So I have added a mutex that does not allow the enumeration while a transfer is happening (callInProgress and callMutex in core); if an enumeration request comes during any transfer, we just reply with the last enumeration result; however, that also means that if communication hangs on forever, enumeration is stuck
* similarly, we want closing to be atomic - so if we close the device, we want to wait until closing to reply in the enumeration that the device is free to use
* however, because of some trezor t HW issues, we still return some data on the bus even when the transfer is cancelled, IF we cancel it mid-transfer (what I wrote about session stealing, it can happen mid read) - so we need to do some "finishing read queue" (fininshReadQueue) - reading data with very short timeouts 
* and libusb sometimes hangs if you close a device in the middle of a transfer, you dont cancel the transfer, and then you try to read or write on the device again - so the close() then hangs because finishReadQueue() hangs and that makes enumeration stuck

---

.....anyway. The whole point of this is - before, we solved all those issues with interrupt transfers with timeouts. Since that sort of worked - the read/write never hangs, unless you do two of them simultaneously or unless you close the device below it, so we added transferMutex for that.

But now we found out that the timeout transfers cause problems, so instead, we used transfers with 0 timeouts and to cancel the transfers, we added a code to our libusb implementation. (We could have rewritten the code to use the async calls, but at which point we are re-implementing sync.c anyway, so why not add the function there when we statically link anyway.) That is done here https://github.com/trezor/trezord-go/pull/104

----

Well. Since as @alexdupre wrote, it is standard to use system libraries on freebsd, we cannot really add stuff to sync.c there; and the timeout approach causes problems (libusb returns LIBUSB_PIPE error). The best solution to me seems to just not allow session stealing on FreeBSD. (Other solutions would be to rewrite sync.c so it works with system libraries, so it does not use libusbi.h. I am too lazy for that. Other solution would be to statically link libusb as we do on other platforms :D) 

That makes trezord still mostly usable on freebsd - just that "session stealing" is not working properly so when user has more tabs, one can block communication for other tabs. That makes it sub-obtimal but still usable - user sees that there is communication in some other tab so he can go and close all other tabs manually.

----

Now I added function to trezord.go that detects whether to allow session stealing (only when the OS is freebsd) and slightly refactored whether to use both webusb.go and hid.go (when not freebsd - or linux, see below)

When I refactored, I realized we can also use libusb for the HID devices on linux - since hidapi uses libusb on linux anyway - so I added a code that uses libusb on linux instead, instead of using hidapi which uses libusb.

At which point I realized we can probaby rename webusb.go to libusb.go and the class from WebUSB to LibUSB, because it makes more sense, so I did that.

....and that is the PR below. :D 