### PR TITLE
udp: Increase timeout

### DIFF
--- a/usb/udp.go
+++ b/usb/udp.go
@@ -18,7 +18,7 @@ var emulatorPong = []byte("PONGPONG")
 const (
 	emulatorPrefix      = "emulator"
 	emulatorAddress     = "127.0.0.1"
-	emulatorPingTimeout = 700 * time.Millisecond
+	emulatorPingTimeout = 5000 * time.Millisecond
 )
 
 type UDP struct {


### PR DESCRIPTION
macOS t1 emulator is fairly slow for some reason.

This makes one thing a little slower - if now you have bridge with UDP enabled, *and* you *don't* have emulator turned on, it will take longer to detect a connected hardware device - since in every iteration, it waits all 5 seconds

I think it's fine - since you need to turn on UDP manually