### PR TITLE
windows7: create AppData before installing

### DIFF
--- a/release/windows/trezord.nsis
+++ b/release/windows/trezord.nsis
@@ -165,8 +165,9 @@ SectionEnd
 Section "Install drivers"
   ${If} ${IsWin7}
   DetailPrint "Installing drivers"
-  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C0 --progressbar=$HWNDPARENT > "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
-  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C1 --iid 0 --progressbar=$HWNDPARENT >> "%AppData%\TREZOR Bridge\wdi-log.txt" 2>&1"'
+  nsExec::ExecToLog '"$sysdir\cmd.exe" /c "mkdir "%APPDATA%\TREZOR Bridge""'
+  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C0 --progressbar=$HWNDPARENT > "%APPDATA%\TREZOR Bridge\wdi-log.txt" 2>&1"'
+  nsExec::ExecToLog '"$sysdir\cmd.exe" /c ""$INSTDIR\wdi-simple.exe" --name "TREZOR" --manufacturer "SatoshiLabs" --vid 0x1209 --pid 0x53C1 --iid 0 --progressbar=$HWNDPARENT >> "%APPDATA%\TREZOR Bridge\wdi-log.txt" 2>&1"'
   ${EndIf}
   nsExec::ExecToLog '"$INSTDIR\devcon.exe" rescan'
 SectionEnd


### PR DESCRIPTION
This is a pretty bad bug that prevented the drivers to be installed on the first install

The AppData/TREZOR Bridge was created only on the first run of bridge. The driver installation script failed, because it could not write its log anywhere.