### PR TITLE
Unique id paths

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -36,6 +36,8 @@ type USBBus interface {
 		reset bool, // reset is optional, to prevent reseting calls
 	) (USBDevice, error)
 	Has(path string) bool
+
+	Close() // called on program exit
 }
 
 type DeviceType int

--- a/memorywriter/memorywriter.go
+++ b/memorywriter/memorywriter.go
@@ -49,7 +49,9 @@ func (m *MemoryWriter) Log(s string) {
 	frame, _ := frames.Next()
 	file := frame.File
 	file = strings.TrimPrefix(file, internalPrefix)
-	r := fmt.Sprintf("[%s %d %s]", file, frame.Line, frame.Function)
+	function := frame.Function
+	function = strings.TrimPrefix(function, "github.com/trezor/trezord-go/")
+	r := fmt.Sprintf("[%s %d %s]", file, frame.Line, function)
 	m.println(r + " " + s)
 
 }

--- a/memorywriter/memorywriter.go
+++ b/memorywriter/memorywriter.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -25,6 +26,7 @@ type MemoryWriter struct {
 	startLines   [][]byte
 	startTime    time.Time
 	printTime    bool
+	mutex        sync.Mutex
 
 	outWriter io.Writer
 }
@@ -63,6 +65,10 @@ func (m *MemoryWriter) println(s string) {
 
 // Writer remembers lines in memory
 func (m *MemoryWriter) Write(p []byte) (int, error) {
+	m.mutex.Lock()
+	defer func() {
+		m.mutex.Unlock()
+	}()
 	if len(p) > maxLineLength {
 		return 0, errors.New("input too long")
 	}
@@ -105,6 +111,10 @@ func (m *MemoryWriter) Write(p []byte) (int, error) {
 // Exports lines to a writer, plus adds additional text on top
 // In our case, additional text is devcon exports and trezord version
 func (m *MemoryWriter) writeTo(start string, w io.Writer) error {
+	m.mutex.Lock()
+	defer func() {
+		m.mutex.Unlock()
+	}()
 	_, err := w.Write([]byte(start))
 	if err != nil {
 		return err

--- a/trezord.go
+++ b/trezord.go
@@ -79,8 +79,6 @@ func initUsb(init bool, wr *memorywriter.MemoryWriter, sl *log.Logger) []core.US
 		if err != nil {
 			sl.Fatalf("libusb: %s", err)
 		}
-		// defer w.Close()
-		// not defering - originally in main, now here, here makes no sense
 
 		if !usb.HIDUse {
 			return []core.USBBus{w}
@@ -159,6 +157,7 @@ func main() {
 	}
 
 	b := usb.Init(bus...)
+	defer b.Close()
 	longMemoryWriter.Log("Creating core")
 	c := core.New(b, longMemoryWriter, allowCancel(), reset)
 	longMemoryWriter.Log("Creating HTTP server")

--- a/usb/bus.go
+++ b/usb/bus.go
@@ -2,13 +2,8 @@ package usb
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/trezor/trezord-go/core"
-)
-
-var (
-	ErrNotFound = fmt.Errorf("device not found")
 )
 
 type USB struct {
@@ -52,6 +47,7 @@ func (b *USB) Connect(path string, debug bool, reset bool) (core.USBDevice, erro
 	return nil, ErrNotFound
 }
 
+var ErrNotFound = errors.New("device not found")
 var errDisconnect = errors.New("device disconnected during action")
 var errClosedDevice = errors.New("closed device")
 var errNotDebug = errors.New("not debug link")

--- a/usb/bus.go
+++ b/usb/bus.go
@@ -47,6 +47,12 @@ func (b *USB) Connect(path string, debug bool, reset bool) (core.USBDevice, erro
 	return nil, ErrNotFound
 }
 
+func (b *USB) Close() {
+	for _, b := range b.buses {
+		b.Close()
+	}
+}
+
 var ErrNotFound = errors.New("device not found")
 var errDisconnect = errors.New("device disconnected during action")
 var errClosedDevice = errors.New("closed device")

--- a/usb/hidapi.go
+++ b/usb/hidapi.go
@@ -106,6 +106,10 @@ func (b *HIDAPI) identify(dev *lowlevel.HidDeviceInfo) string {
 	return hidapiPrefix + hex.EncodeToString(digest[:])
 }
 
+func (b *HIDAPI) Close() {
+	// nothing
+}
+
 type HID struct {
 	dev     *lowlevel.HidDevice
 	prepend bool // on windows, see detectPrepend

--- a/usb/hidapi_shim.go
+++ b/usb/hidapi_shim.go
@@ -44,3 +44,7 @@ func (d *HID) Write(buf []byte) (int, error) {
 func (d *HID) Read(buf []byte) (int, error) {
 	panic("not implemented for linux and freebsd")
 }
+
+func (b *HIDAPI) Close() {
+	panic("not implemented for linux and freebsd")
+}

--- a/usb/udp.go
+++ b/usb/udp.go
@@ -181,6 +181,10 @@ func (udp *UDP) Connect(path string, debug bool, reset bool) (core.USBDevice, er
 	return d, nil
 }
 
+func (udp *UDP) Close() {
+	// nothing
+}
+
 type UDPDevice struct {
 	lowlevel *udpLowlevel
 


### PR DESCRIPTION
Significant reworking of libusb enumeration and paths

So far, "path" was actually a USB port, but that could cause some issues when the device was disconnected and then reconnected again, when the service was not constantly watching uploads via listen. That was unfixable.

Instead of that, I have rewritten the libusb to use "paths" that are unique for each device and increase every device connection/disconnection. I compare devices by just comparing pointers of libusb lowlevel objects.

However there are 2 issues on windows:

1) we still have the other bug with multiple devices on windows, so we have to work around that

2) on windows, if the device is disconnected and connected again without enumerate (or acquire) between, or if it's two bootloader devices, the path does not increase. (but does increase when there is enumerate in between)

First is solved, secon is not that big of an issue I guess

cc @matejcik , again :)