### PR TITLE
Lock sessionsMutex when deleting session

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -351,12 +351,15 @@ func (c *Core) release(
 	debug bool,
 ) error {
 	c.log.Log(fmt.Sprintf("session %s", session))
+	c.sessionsMutex.Lock()
 	acquired := (c.sessions(debug))[session]
 	if acquired == nil {
 		c.log.Log("session not found")
+		c.sessionsMutex.Unlock()
 		return ErrSessionNotFound
 	}
 	delete(c.sessions(debug), session)
+	c.sessionsMutex.Unlock()
 
 	c.log.Log("bus close")
 	err := acquired.dev.Close(disconnected)


### PR DESCRIPTION
When built with `-race`, running acquire and then:

```
echo -n "001400000000" | http -v POST "127.0.0.1:21325/call/2"
```

(`001400000000` is just an example of Cancel message, http command is [httpie](https://httpie.org/), use whatever you want.)

following with a release command:

```
http -v POST "127.0.0.1:21325/release/2"
```

I am receiving a race condition warning as mentioned in https://github.com/trezor/trezord-go/issues/190#issuecomment-627142657. I believe that in some rare cases this could have led to a crash when two concurrent writes actually happened? In @mroz22's case (see the issue) it was concurrent iteration and write, so my guess is it was Acquire's `findPrevSession` and Release's `delete`.

----

This PR adds sessionsMutex lock to `release` so the calls are separated. Running the test case above does not show the warning anymore.

Fixes #190 