### PR TITLE
Introduce debug build mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ directory will produce a new executable at the same place. Running
 `go build github.com/trezor/trezord-go` will produce a new executable in `$GOPATH/bin`. Both are built
 from your local copy in `$GOPATH/src`.
 
+#### Debug mode
+
+When built with `-tags debug` a debug mode is enabled. This disables CORS which is helpful for local development and when run inside a docker image.
+
 ## Update from source
 ```
 go clean

--- a/core/debug.go
+++ b/core/debug.go
@@ -1,0 +1,7 @@
+// +build debug
+
+package core
+
+func IsDebugBinary() bool {
+	return true
+}

--- a/core/release.go
+++ b/core/release.go
@@ -1,0 +1,7 @@
+// +build !debug
+
+package core
+
+func IsDebugBinary() bool {
+	return false
+}

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -46,11 +46,13 @@ func ServeAPI(r *mux.Router, c *core.Core, v string, l *memorywriter.MemoryWrite
 	r.HandleFunc("/debug/call/{session}", api.CallDebug)
 	r.HandleFunc("/debug/post/{session}", api.PostDebug)
 	r.HandleFunc("/debug/read/{session}", api.ReadDebug)
-	corsv, err := corsValidator()
-	if err != nil {
-		return err
+	if !core.IsDebugBinary() {
+		corsv, err := corsValidator()
+		if err != nil {
+			return err
+		}
+		r.Use(CORS(corsv))
 	}
-	r.Use(CORS(corsv))
 	return nil
 }
 

--- a/trezord.go
+++ b/trezord.go
@@ -139,11 +139,7 @@ func main() {
 
 	longMemoryWriter := memorywriter.New(90000, 200, true, verboseWriter)
 
-	stderrLogger.Printf("trezord v%s is starting.", version)
-	if core.IsDebugBinary() {
-		stderrLogger.Print("DEBUG mode enabled! Please contact Trezor support in case you did not initiate this.")
-	}
-
+	printWelcomeInfo(stderrLogger)
 	bus := initUsb(withusb, longMemoryWriter, stderrLogger)
 
 	longMemoryWriter.Log(fmt.Sprintf("UDP port count - %d", len(ports)))
@@ -184,6 +180,13 @@ func main() {
 	}
 
 	longMemoryWriter.Log("Main ended successfully")
+}
+
+func printWelcomeInfo(stderrLogger *log.Logger) {
+	stderrLogger.Printf("trezord v%s is starting.", version)
+	if core.IsDebugBinary() {
+		stderrLogger.Print("!! DEBUG mode enabled! Please contact Trezor support in case you did not initiate this. !!")
+	}
 }
 
 // Does OS allow sync canceling via our custom libusb patches?

--- a/trezord.go
+++ b/trezord.go
@@ -140,6 +140,9 @@ func main() {
 	longMemoryWriter := memorywriter.New(90000, 200, true, verboseWriter)
 
 	stderrLogger.Printf("trezord v%s is starting.", version)
+	if core.IsDebugBinary() {
+		stderrLogger.Print("DEBUG mode enabled! Please contact Trezor support in case you did not initiate this.")
+	}
 
 	bus := initUsb(withusb, longMemoryWriter, stderrLogger)
 


### PR DESCRIPTION
When build using `go build -tags debug` a debug mode is enabled. Currently that means disabling CORS, which is helpful for local development and when run inside a docker image.