### PR TITLE
migrated tests from travis 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,14 +1,22 @@
-image: docker:latest
-
-services:
-  - docker:dind
-
-build and push emulator image:
-  before_script:
-    - apk add --no-cache py-pip
-    - pip install docker-compose
-    - docker login $CI_REGISTRY -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD
-  when: manual
+build test:
+  stage: test
+  image: golang
   script:
-    - docker-compose -f ./docker-compose.yml build
-    - docker-compose -f ./docker-compose.yml push
+    - go version
+    - go build .
+    - go test -v ./...
+
+go lint:
+  stage: test
+  image: golang
+  script:
+    - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.32.0
+    - golangci-lint run
+
+version check:
+  stage: test
+  image: golang
+  script:
+    - diff -u VERSION <(grep "var version = " trezord.go | cut -f 2 -d '"')
+
+#Gitlab does not support xgo building without hacking the base xgo image, for now builds are done manually until we find a better solution.


### PR DESCRIPTION
Aded tests from travis ci to gitlab ci, for now only test are able to run on gitlab ci. Unfortunately no builds since xgo is not supported on gitlab without some hacking to the source.