### PR TITLE
Moved the creation of logfile from pre-install package script to systemd init script

### DIFF
--- a/release/linux/fpm.before-install.sh
+++ b/release/linux/fpm.before-install.sh
@@ -2,6 +2,3 @@ getent group trezord >/dev/null || groupadd -r trezord
 getent group plugdev >/dev/null || groupadd -r plugdev
 getent passwd trezord >/dev/null || useradd -r -g trezord -d /var -s /bin/false -c "Trezor Bridge" trezord
 usermod -a -G plugdev trezord
-touch /var/log/trezord.log
-chown trezord:trezord /var/log/trezord.log
-chmod 660 /var/log/trezord.log

--- a/release/linux/trezord.service
+++ b/release/linux/trezord.service
@@ -4,6 +4,11 @@ After=network.target
 
 [Service]
 Type=simple
+
+ExecStartPre=/usr/bin/touch /var/log/trezord.log
+ExecStartPre=/usr/bin/chown trezord:trezord /var/log/trezord.log
+ExecStartPre=/usr/bin/chmod 660 /var/log/trezord.log
+
 ExecStart=/usr/bin/trezord
 User=trezord
 


### PR DESCRIPTION
I have not tried to build the a new rpm/deb, but replacing the existing systemd init script and running `systemctl daemon-reload` on Fedora 35 works. 

```
$ systemctl status trezord.service
● trezord.service - Trezor Bridge
     Loaded: loaded (/usr/lib/systemd/system/trezord.service; enabled; vendor preset: disabled)
     Active: active (running) since Mon 2022-05-23 15:40:15 CEST; 5s ago
    Process: 309481 ExecStartPre=/usr/bin/touch /var/log/trezord.log (code=exited, status=0/SUCCESS)
    Process: 309482 ExecStartPre=/usr/bin/chown trezord:trezord /var/log/trezord.log (code=exited, status=0/SUCCESS)
    Process: 309483 ExecStartPre=/usr/bin/chmod 660 /var/log/trezord.log (code=exited, status=0/SUCCESS)
   Main PID: 309484 (trezord)
      Tasks: 8 (limit: 23797)
     Memory: 1.9M
        CPU: 40ms
     CGroup: /system.slice/trezord.service
             └─309484 /usr/bin/trezord

May 23 15:40:15 fedora systemd[1]: Starting Trezor Bridge...
May 23 15:40:15 fedora systemd[1]: Started Trezor Bridge.
May 23 15:40:15 fedora trezord[309484]: 2022/05/23 15:40:15 trezord v2.0.27 is starting.
```

Systemd init script requires full path to the executable, so it might break some special systems where the binaries are not in `/usr/bin`. 

Fedora 35:
```
$ whereis -b touch chown chmod
touch: /usr/bin/touch
chown: /usr/bin/chown
chmod: /usr/bin/chmod
```