### PR TITLE
fix: close libusb config description memory leak

### DIFF
--- a/usb/libusb.go
+++ b/usb/libusb.go
@@ -92,6 +92,7 @@ func hasIface(dev lowlevel.Device, dIface libusbIfaceData, dClass uint8) (bool, 
 	if err != nil {
 		return false, err
 	}
+	defer lowlevel.Free_Config_Descriptor(config)
 
 	ifaces := config.Interface
 	for _, iface := range ifaces {
@@ -363,6 +364,7 @@ func (b *LibUSB) match(dev lowlevel.Device) (bool, core.DeviceType) {
 		b.mw.Log("error getting config descriptor " + err.Error())
 		return false, 0
 	}
+	defer lowlevel.Free_Config_Descriptor(c)
 
 	b.mw.Log("let's test")
 


### PR DESCRIPTION
The config descriptors from the libusb c-library are not being properly closed by the golang code.

On my PC, when testing with MetaMask, this causes an approximately 10 MB per hour memory leak. This memory leak is not detected via golang's  pprof, as it's in the c-library.

Closing these config descriptors using `defer` seems to fix this memory leak in my testing.

This seems to fix #223 (at least for me!). `trezord-go` now seems to pretty stable at around 50 MB.

### More info

In order to find this memory leak, I first added a `pprof` API call to `trezord-go`, which I used to get performance data on the golang heap and co-routine (let me know if you'd be interested in a PR for this too).

What I found was that according to `pprof`, there was no memory leak.

However, according to Linux, `trezord-go` was still leaking ~10MB/h, so I assumed the memory leak wasn't in golang, but in the underlying C libraries, so I tried running `trezord-go` through `valgrind` to see if I could spot a memory leak there.

```bash
valgrind --leak-check=full --show-leak-kinds=all --verbose ./trezord-go
```

After playing around with my Trezor a bit, I pressed `CTRL+C` and got the following results:

```
==905747== 80 bytes in 2 blocks are indirectly lost in loss record 301 of 566
==905747==    at 0x483B723: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==905747==    by 0x483E017: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==905747==    by 0x7F55C6: parse_interface (descriptor.c:206)
==905747==    by 0x7F55C6: parse_configuration (descriptor.c:439)
==905747==    by 0x7F55C6: raw_desc_to_config (descriptor.c:467)
==905747==    by 0x7F63A0: libusb_get_config_descriptor (descriptor.c:629)
==905747==    by 0x7FE1E2: _cgo_0328dca10925_Cfunc_libusb_get_config_descriptor (cgo-gcc-prolog:565)
==905747==    by 0x4641DF: runtime.asmcgocall (/usr/lib/go-1.13/src/runtime/asm_amd64.s:655)
==905747==    by 0x46074B: runtime.(*mheap).alloc.func1 (/usr/lib/go-1.13/src/runtime/mheap.go:1093)
==905747==    by 0x40543: ???
==905747==    by 0x439F3F: ??? (/usr/lib/go-1.13/src/runtime/proc.go:1080)
==905747==    by 0x462893: runtime.rt0_go (/usr/lib/go-1.13/src/runtime/asm_amd64.s:220)
...
==905747== 128 bytes in 2 blocks are still reachable in loss record 326 of 566
==905747==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==905747==    by 0x7F57C4: parse_interface (descriptor.c:298)
==905747==    by 0x7F57C4: parse_configuration (descriptor.c:439)
==905747==    by 0x7F57C4: raw_desc_to_config (descriptor.c:467)
==905747==    by 0x7F62A0: libusb_get_active_config_descriptor (descriptor.c:584)
==905747==    by 0x7FE12E: _cgo_0328dca10925_Cfunc_libusb_get_active_config_descriptor (cgo-gcc-prolog:504)
==905747==    by 0x4641DF: runtime.asmcgocall (/usr/lib/go-1.13/src/runtime/asm_amd64.s:655)
==905747==    by 0x46074B: runtime.(*mheap).alloc.func1 (/usr/lib/go-1.13/src/runtime/mheap.go:1093)
==905747==    by 0x12B7: ???
==905747==    by 0x439F3F: ??? (/usr/lib/go-1.13/src/runtime/proc.go:1080)
==905747==    by 0x462893: runtime.rt0_go (/usr/lib/go-1.13/src/runtime/asm_amd64.s:220)
```

There were a couple of other memory leaks reported, but all that I saw had the lines `libusb_get_config_descriptor` or `libusb_get_active_config_descriptor` in them.

![Figure_1](https://user-images.githubusercontent.com/19716675/185243437-977415ca-6c22-4193-b17c-44a571029109.svg)

_Edit: Updated graph with more results_
