### PR TITLE
fix(linux): remove /var/log/trezord.log creation

### DIFF
--- a/release/linux/fpm.before-install.sh
+++ b/release/linux/fpm.before-install.sh
@@ -2,6 +2,3 @@ getent group trezord >/dev/null || groupadd -r trezord
 getent group plugdev >/dev/null || groupadd -r plugdev
 getent passwd trezord >/dev/null || useradd -r -g trezord -d /var -s /bin/false -c "Trezor Bridge" trezord
 usermod -a -G plugdev trezord
-touch /var/log/trezord.log
-chown trezord:trezord /var/log/trezord.log
-chmod 660 /var/log/trezord.log


### PR DESCRIPTION
As far as I'm aware, Linux has never logged to `/var/log/trezord.log` (I did a quick search through `git blame` and couldn't find anything).

Because of that, there's no reason to even create the `/var/log/trezord.log` file.

On my PC, `ls -lhrt /var/log/trezord.log` shows that it has 0 bytes, and has been unmodified since 2021. 

```console
user@computer:~$ sudo ls -lhrt /var/log/trezord.log 
-rw-rw---- 1 trezord trezord 0 Oct 17  2021 /var/log/trezord.log
```

Instead, Linux just relies on systemd's logger. On most new devices, you can view these logs via `journalctl -u trezord`.

I'm 99.9% sure this will fix #245 and fix #246, but I don't run Fedora or Fedora Silverblue, so it might be worth @hegjon or @triceo testing (if they're still interested) 