### PR TITLE
Fix failing CI by linting with golang v1.17

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,9 @@ build test:
 
 go lint:
   stage: test
-  image: golang
+  # golangci-lint v1.45.1 is the first version that supports golang 1.18
+  # see https://github.com/golangci/golangci-lint/releases/tag/v1.45.0
+  image: golang:1.17
   script:
     - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.32.0
     - golangci-lint run


### PR DESCRIPTION
The golangci-lint job is failing on GitLab CI, see https://gitlab.com/satoshilabs/trezor/trezord-go/-/commit/ec928e6456bfa60c9a298ae78613f723db256900/pipelines?ref=master

This is because only v1.45.1 of golangci-lint supports golang v1.18.0, see https://github.com/golangci/golangci-lint-action/issues/434#issuecomment-1086127909

It's also possible to fix this bug by updating the `golangci-lint`, but that causes a bunch of warnings and errors, so it's probably easier to just keep the golang version at `v1.17`.