### PR TITLE
Rework build, replace xgo with golang-crossbuild

### DIFF
--- a/release/macos/Dockerfile
+++ b/release/macos/Dockerfile
@@ -12,8 +12,8 @@ RUN dnf install -y gcc gcc-c++ git make gzip cpio findutils autoconf libxml2-dev
 
 # build bomutils and xar from sources with fixes
 
+RUN git clone https://github.com/tpoechtrager/xar
+RUN cd xar && cd xar && ./autogen.sh --noconfigure && ./configure && make && make install
+
 RUN git clone https://github.com/BC-SECURITY/bomutils
 RUN cd bomutils && CFLAGS="-fsigned-char" make && make install
-
-RUN git clone https://github.com/tpoechtrager/xar
-RUN cd xar && cd xar && ./autogen.sh --noconfigure && CFLAGS="-fsigned-char" ./configure && make && make install

--- a/release/macos/Dockerfile
+++ b/release/macos/Dockerfile
@@ -1,6 +1,6 @@
 # initialize from the image
 
-FROM fedora:25
+FROM fedora:36
 
 # update package repositories
 
@@ -10,13 +10,10 @@ RUN dnf update -y
 
 RUN dnf install -y gcc gcc-c++ git make gzip cpio findutils autoconf libxml2-devel openssl-devel
 
-# build bomutils from source
+# build bomutils and xar from sources with fixes
 
-RUN git clone https://github.com/hogliux/bomutils.git
-RUN cd bomutils && make && make install
+RUN git clone https://github.com/BC-SECURITY/bomutils
+RUN cd bomutils && CFLAGS="-fsigned-char" make && make install
 
-# build xar from source
-# (xar in Fedora is old and its results don't work in macOS)
-
-RUN git clone https://github.com/mackyle/xar.git
-RUN cd xar && cd xar && ./autogen.sh --noconfigure && ./configure && make && make install
+RUN git clone https://github.com/tpoechtrager/xar
+RUN cd xar && cd xar && ./autogen.sh --noconfigure && CFLAGS="-fsigned-char" ./configure && make && make install

--- a/release/macos/Makefile
+++ b/release/macos/Makefile
@@ -14,7 +14,7 @@ clean:
 	rm -rf build
 
 .binary:
-	$(info Building with xgo ...)
+	$(info Building with crossbuild ...)
 	mkdir -p build
 	docker run -it --rm \
 		-v $(IMPORT_PATH):/trezord \

--- a/release/macos/Makefile
+++ b/release/macos/Makefile
@@ -5,7 +5,7 @@ IMAGETAG  = trezord-go-build-env-$(PLATFORM)
 
 GITHASH  := $(shell git rev-parse --short HEAD)
 
-IMPORT_PATH = ../..
+IMPORT_PATH = $(shell realpath ../..)
 
 all: clean .package
 
@@ -16,8 +16,26 @@ clean:
 .binary:
 	$(info Building with xgo ...)
 	mkdir -p build
-	xgo -ldflags="-X 'main.githash=$(GITHASH)'" -targets=darwin-10.10/amd64 $(IMPORT_PATH)
-	mv -f trezord-go-darwin-10.10-amd64 build/trezord
+	docker run -it --rm \
+		-v $(IMPORT_PATH):/trezord \
+		-w /trezord \
+		-e CGO_ENABLED=1 \
+		docker.elastic.co/beats-dev/golang-crossbuild:1.19-darwin-debian10 \
+		--build-cmd "go build -o release/macos/build/trezord-amd64" \
+		-p "darwin/amd64"
+	docker run -it --rm \
+		-v $(IMPORT_PATH):/trezord \
+		-w /trezord \
+		-e CGO_ENABLED=1 \
+		docker.elastic.co/beats-dev/golang-crossbuild:1.19-darwin-arm64-debian10 \
+		--build-cmd "go build -o release/macos/build/trezord-arm64" \
+		-p "darwin/arm64"
+	docker run -it --rm \
+		-v $(IMPORT_PATH):/trezord \
+		-w /trezord \
+		-e CGO_ENABLED=1 \
+		--entrypoint /trezord/release/macos/build-fat.sh \
+		docker.elastic.co/beats-dev/golang-crossbuild:1.19-darwin-arm64-debian10
 	cp ../../VERSION build
 
 .package: .binary .docker-image

--- a/release/macos/build-fat.sh
+++ b/release/macos/build-fat.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -ex
+
+/usr/local/osxcross/bin/lipo \
+   -create release/macos/build/trezord-arm64 release/macos/build/trezord-amd64 \
+   -output release/macos/build/trezord

--- a/release/macos/release.sh
+++ b/release/macos/release.sh
@@ -26,14 +26,19 @@ cp -r /release/flat-uninstall /release/build
 cd /release/build/flat-uninstall/uninstall.pkg
 
 cd scripts
-find . | cpio -o --format odc --owner 0:80 | gzip -c > ../Scripts
+find . | cpio -o --format odc --owner 0:80 | gzip -c > ../Scripts-zip
 cd ..
+ls -l payload/
+ls -l scripts/
 rm -r scripts
+mv Scripts-zip Scripts
 cd payload
-find . | cpio -o --format odc --owner 0:80 | gzip -c > ../Payload
+find . | cpio -o --format odc --owner 0:80 | gzip -c > ../Payload-zip
 cd ..
+ls -l payload/
 mkbom -u 0 -g 80 payload/ Bom
 rm -r payload
+mv Payload-zip Payload
 cd ..
 sed -i s/VERSION/$VERSION/g Distribution
 sed -i s/VERSION/$VERSION/g uninstall.pkg/PackageInfo
@@ -49,9 +54,10 @@ rm -rf /release/build/flat-install
 cp -r /release/flat-install /release/build
 cd /release/build/flat-install/install.pkg
 cd scripts
-find . | cpio -o --format odc --owner 0:80 | gzip -c > ../Scripts
+find . | cpio -o --format odc --owner 0:80 | gzip -c > ../Scripts-zip
 cd ..
 rm -r scripts
+mv Scripts-zip Scripts
 cd payload
 
 cp /release/build/trezord Applications/Utilities/TREZOR\ Bridge/
@@ -60,11 +66,12 @@ cp ../../../uninstall.pkg Applications/Utilities/TREZOR\ Bridge/
 FILES=$(find . | wc -l)
 KBYTES=$(du -k -s . | cut -f 1)
 
-find . | cpio -o --format odc --owner 0:80 | gzip -c > ../Payload
+find . | cpio -o --format odc --owner 0:80 | gzip -c > ../Payload-zip
 cd ..
 mkbom -u 0 -g 80 payload/ Bom
 
 rm -r payload
+mv Payload-zip Payload
 cd ..
 sed -i s/VERSION/$VERSION/g Distribution
 sed -i s/KBYTES/$KBYTES/g Distribution


### PR DESCRIPTION
xgo is deprecated. Let's replace it with Elastic's Golang-crossbuild.

It is better documented and more maintained.

https://github.com/elastic/golang-crossbuild

That docker conveniently also has lipo, which will make the fat binary.