### PR TITLE
Remove githash from Makefiles, move to go code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 NAME         := trezord
 PLATFORMS    := linux-arm64 linux-x64 win-x64 # mac-x64
 
-GITHASH      := $(shell git rev-parse --short HEAD)
-
-GOFLAGS      := -a -ldflags="-X 'main.githash=$(GITHASH)'"
+GOFLAGS      := -a
 
 LINUX_CFLAGS := -Wno-deprecated-declarations
 MAC_CFLAGS   := -Wno-deprecated-declarations -Wno-unknown-warning-option

--- a/release/linux/Makefile
+++ b/release/linux/Makefile
@@ -2,8 +2,6 @@ PLATFORM  = linux
 VOL_MOUNT = -v $(shell pwd):/release
 IMAGETAG  = trezord-go-build-env-$(PLATFORM)
 
-GITHASH  := $(shell git rev-parse --short HEAD)
-
 IMPORT_PATH = ../..
 
 all: clean .package
@@ -15,7 +13,7 @@ clean:
 .binary:
 	$(info Building with xgo ...)
 	mkdir -p build
-	xgo -ldflags="-X 'main.githash=$(GITHASH)'" -targets=linux/386,linux/amd64,linux/arm64 $(IMPORT_PATH)
+	xgo -targets=linux/386,linux/amd64,linux/arm64 $(IMPORT_PATH)
 	mv -f trezord-go-linux-386 build/trezord-linux-386
 	mv -f trezord-go-linux-amd64 build/trezord-linux-amd64
 	mv -f trezord-go-linux-arm64 build/trezord-linux-arm64

--- a/release/macos/Makefile
+++ b/release/macos/Makefile
@@ -3,8 +3,6 @@ BITS      = 64
 VOL_MOUNT = -v $(shell pwd):/release
 IMAGETAG  = trezord-go-build-env-$(PLATFORM)
 
-GITHASH  := $(shell git rev-parse --short HEAD)
-
 IMPORT_PATH = $(shell realpath ../..)
 
 all: clean .package

--- a/release/windows/Makefile
+++ b/release/windows/Makefile
@@ -3,8 +3,6 @@ BITS      = 32
 VOL_MOUNT = -v $(shell pwd):/release
 IMAGETAG  = trezord-go-build-env-$(PLATFORM)
 
-GITHASH  := $(shell git rev-parse --short HEAD)
-
 WDI_VOL_MOUNT = -v $(shell pwd):/release
 WDI_IMAGETAG  = trezord-go-wdi-build
 
@@ -22,7 +20,7 @@ clean:
 .binary:
 	$(info Building with xgo ...)
 	mkdir -p build
-	xgo -ldflags="-H=windowsgui -X 'main.githash=$(GITHASH)'" -targets=windows-6.0/386,windows-6.0/amd64 $(IMPORT_PATH)
+	xgo -ldflags="-H=windowsgui" -targets=windows-6.0/386,windows-6.0/amd64 $(IMPORT_PATH)
 	mv -f trezord-go-windows-6.0-386.exe build/trezord-32b.exe
 	mv -f trezord-go-windows-6.0-amd64.exe build/trezord-64b.exe
 	cp ../../VERSION build

--- a/trezord.go
+++ b/trezord.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -96,6 +97,17 @@ func initUsb(init bool, wr *memorywriter.MemoryWriter, sl *log.Logger) []core.US
 }
 
 func main() {
+	// set git hash
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		log.Fatalf("cannot read build info")
+	}
+	for _, v := range info.Settings {
+		if v.Key == "vcs.revision" {
+			githash = v.Value[0:7]
+		}
+	}
+
 	var logfile string
 	var ports udpPorts
 	var touples udpTouples


### PR DESCRIPTION
In go 1.18, go is "magically" putting git hash to binary itself, which can be read in the code itself. So we don't need the `git parse` in Makefiles.

(I actually forgot to put the GITHASH magic to the osx build, but better to fix it properly.)

The module version is _not_ put there, as it's hard to tell from just git. So we still need that there.