### PR TITLE
Fix linux build for linux hosts

### DIFF
--- a/release/linux/build.sh
+++ b/release/linux/build.sh
@@ -3,6 +3,8 @@
 set -ex
 PATH=$PATH:/usr/local/go/bin
 
+git config --global --add safe.directory /trezord
+
 case $TREZORD_BUILD in
   "go-arm64-musl")
     CGO_ENABLED=1 CC="/usr/local/musl/bin/aarch64-unknown-linux-musl-gcc" GOARCH=arm64 \


### PR DESCRIPTION
The issue is with new git, and Linux Docker hosts.

It's a mitigation against CVE-2022-24765, as the owner of the outside repo needs to be the same as the current user; and the user inside the docker container is root. (Go is running git to do the version stamping.)

Simple fix is to add a safe directory, as the CVE does not apply to us.