### PR TITLE
Clean makefiles, move GPG signing to release.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,14 +3,16 @@
 .fseventsd
 .Spotlight-V100
 
-# Project related 
+# Project related
 trezord-go
 build/
 release/installers/
+release/binaries/
 release/linux/privkey.asc
 release/linux/build/
 release/macos/cert0*
 release/macos/key.pem
+release/macos/gpg-privkey.asc
 release/macos/certs/installer.passphrase
 release/macos/certs/installer.p12
 release/macos/certs/app.passphrase
@@ -21,3 +23,4 @@ release/macos/certs/notarization-authkey.p8
 release/macos/build/
 release/windows/authenticode.*
 release/windows/build/
+release/windows/gpg-privkey.asc

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,5 @@
-NAME         := trezord
-PLATFORMS    := linux-arm64 linux-x64 win-x64 # mac-x64
-
-GOFLAGS      := -a
-
-LINUX_CFLAGS := -Wno-deprecated-declarations
-MAC_CFLAGS   := -Wno-deprecated-declarations -Wno-unknown-warning-option
-WIN_CFLAGS   := -Wno-deprecated-declarations -Wno-implicit-function-declaration -Wno-stringop-overflow
-
-BUILD_DIR    := build
-TARGETS      := $(foreach platform,$(PLATFORMS),$(BUILD_DIR)/$(NAME)-$(platform))
-
-all: $(TARGETS)
-
-$(BUILD_DIR):
-	mkdir -p $(BUILD_DIR)
-
-$(BUILD_DIR)/$(NAME)-linux-arm64: $(BUILD_DIR)
-	CC=aarch64-unknown-linux-gnu-gcc CGO_ENABLED=1 CGO_CFLAGS="$(LINUX_CFLAGS)" GOOS=linux GOARCH=arm64 go build $(GOFLAGS) -o $(BUILD_DIR)/$(NAME)-linux-arm64
-
-$(BUILD_DIR)/$(NAME)-linux-x64: $(BUILD_DIR)
-	CC=gcc CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CGO_CFLAGS="$(LINUX_CFLAGS)" go build $(GOFLAGS) -o $(BUILD_DIR)/$(NAME)-linux-x64
-
-$(BUILD_DIR)/$(NAME)-mac-x64: $(BUILD_DIR)
-	CC=x86_64-apple-darwin14-clang CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 CGO_CFLAGS="$(MAC_CFLAGS)" go build $(GOFLAGS) -o $(BUILD_DIR)/$(NAME)-mac-x64
-
-$(BUILD_DIR)/$(NAME)-win-x64: $(BUILD_DIR)
-	CC=x86_64-w64-mingw32-gcc CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CGO_CFLAGS="$(WIN_CFLAGS)" go build $(GOFLAGS) -o $(BUILD_DIR)/$(NAME)-win-x64
-
 native:
 	CGO_ENABLED=1 go build $(GOFLAGS)
 
-check:
-	file $(TARGETS)
-
-clean:
-	rm -f $(TARGETS)
+build-release:
+	make -C release

--- a/release/Makefile
+++ b/release/Makefile
@@ -1,6 +1,6 @@
 .PHONY: windows linux macos copy gpg clean
 
-all: windows linux macos copy gpg
+all: windows linux macos copy
 
 linux:
 	make -C linux all
@@ -14,13 +14,15 @@ windows:
 copy:
 	rm -rf installers
 	mkdir installers
-	cp macos/build/*.pkg installers
-	cp windows/build/trezor-bridge*.exe installers
+	cp macos/build/trezor-bridge*.pkg* installers
+	cp windows/build/trezor-bridge*.exe* installers
 	cp linux/build/*.deb linux/build/*.rpm installers
-
-gpg:
-	gpg -u 54067D8BBF00554181B5AB8F26A3A56662F0E7E2 --armor --detach-sig installers/trezor-bridge*.exe
-	gpg -u 54067D8BBF00554181B5AB8F26A3A56662F0E7E2 --armor --detach-sig installers/*.pkg
+	rm -rf binaries
+	mkdir binaries
+	cp macos/build/trezord binaries/trezord-darwin-universal
+	cp windows/build/trezord-32b.exe binaries/trezord-windows-386.exe
+	cp windows/build/trezord-64b.exe binaries/trezord-windows-amd64.exe
+	cp linux/build/trezord-linux-* binaries/
 
 clean:
 	rm -rf installers

--- a/release/linux/release.sh
+++ b/release/linux/release.sh
@@ -4,7 +4,6 @@ set -e
 
 cd $(dirname $0)
 
-GPGSIGNKEY=54067D8BBF00554181B5AB8F26A3A56662F0E7E2
 TARGET=$1
 VERSION=$(cat /release/build/VERSION)
 
@@ -21,6 +20,7 @@ if [ -r $GPG_PRIVKEY ]; then
     export LC_ALL=C.UTF-8
     gpg --import /release/privkey.asc
     GPG_SIGN=gpg
+    GPGSIGNKEY=$(gpg --list-keys --with-colons | grep '^pub' | cut -d ":" -f 5)
 fi
 
 NAME=trezor-bridge

--- a/release/macos/Dockerfile
+++ b/release/macos/Dockerfile
@@ -8,7 +8,7 @@ RUN dnf update -y
 
 # install tools
 
-RUN dnf install -y gcc gcc-c++ git make gzip cpio findutils autoconf libxml2-devel openssl-devel cargo
+RUN dnf install -y gcc gcc-c++ git make gzip cpio findutils autoconf libxml2-devel openssl-devel cargo gpg
 
 # build bomutils and xar from sources with fixes
 

--- a/release/macos/release.sh
+++ b/release/macos/release.sh
@@ -157,3 +157,12 @@ if [ -r $NOT_KEY_ID_F ]; then
         $INSTALLER
     rm $NOT_JSON
 fi
+
+GPG_PRIVKEY=/release/gpg-privkey.asc
+if [ -r $GPG_PRIVKEY ]; then
+    export GPG_TTY=$(tty)
+    export LC_ALL=C.UTF-8
+    gpg --import /release/privkey.asc
+    GPGSIGNKEY=$(gpg --list-keys --with-colons | grep '^pub' | cut -d ":" -f 5)
+    gpg -u $GPGSIGNKEY --armor --detach-sig /release/build/*.pkg
+fi

--- a/release/windows/Dockerfile
+++ b/release/windows/Dockerfile
@@ -8,4 +8,4 @@ RUN dnf update -y
 
 # install tools
 
-RUN dnf install -y osslsigncode mingw32-nsis git
+RUN dnf install -y osslsigncode mingw32-nsis git gpg

--- a/release/windows/release.sh
+++ b/release/windows/release.sh
@@ -38,3 +38,14 @@ if [ -r $SIGNKEY.key ]; then
     osslsigncode sign -certs $SIGNKEY.crt -key $SIGNKEY.key -n "Trezor Bridge" -i "https://trezor.io/" -h sha384 -t "http://timestamp.comodoca.com?td=sha384" -in $INSTALLER.unsigned -out $INSTALLER
     osslsigncode verify -in $INSTALLER
 fi
+
+GPG_PRIVKEY=/release/gpg-privkey.asc
+echo 1
+if [ -r $GPG_PRIVKEY ]; then
+    echo 2
+    export GPG_TTY=$(tty)
+    export LC_ALL=C.UTF-8
+    gpg --import /release/privkey.asc
+    GPGSIGNKEY=$(gpg --list-keys --with-colons | grep '^pub' | cut -d ":" -f 5)
+    gpg -u $GPGSIGNKEY --armor --detach-sig $INSTALLER
+fi


### PR DESCRIPTION
I have cleaned up the makefiles. I have also moved the GPG signing to the individual releases and out of existing Makefile.

Also I read the GPG key out of GPG instead of hard-coding it.

The negative is that now we require quite a lot of keys to set up... especially the macos now needs tons of keys.

I will try to document them all somewhere.