### PR TITLE
Remove warnings caused by libusb go code

### DIFF
--- a/usb/lowlevel/libusb/libusb.go
+++ b/usb/lowlevel/libusb/libusb.go
@@ -42,7 +42,7 @@ extern void goLibusbLog(const char *s);
 
 
 #if defined(OS_LINUX)
-	#include <sys/poll.h>
+	#include <poll.h>
 	#include "libusbi.h"
 	#include "os/threads_posix.c"
 	#include "os/events_posix.c"
@@ -930,10 +930,6 @@ func (e *libusb_error) Error() string {
 
 //-----------------------------------------------------------------------------
 // Library initialization/deinitialization
-
-func Set_Debug(ctx Context, level int) {
-	C.libusb_set_debug(ctx, C.int(level))
-}
 
 func Init(ctx *Context) error {
 	rc := int(C.libusb_init((**C.struct_libusb_context)(ctx)))


### PR DESCRIPTION
There were 2 warnings, caused by libusb go code:

* on linux, use POSIX header instead of "incorrect" header that is redirected
* remove unused libusb set_debug from go code (as that caused deprecation warnings)

By the way. The original go library, that we used, is no longer maintained; but it's just a thin wrapper around libusb itself.