### PR TITLE
Fix windows warning by adding Win 7 WIN32_WINNT

### DIFF
--- a/release/windows/Makefile
+++ b/release/windows/Makefile
@@ -18,6 +18,7 @@ clean:
 		-v $(IMPORT_PATH):/trezord \
 		-w /trezord \
 		-e CGO_ENABLED=1 \
+		-e CGO_CFLAGS="-D_WIN32_WINNT=0x0600" \
 		docker.elastic.co/beats-dev/golang-crossbuild:1.19-main-debian10 \
 		--build-cmd "go build -o release/windows/build/trezord-64b.exe -ldflags=\"-H=windowsgui\"" \
 		-p "windows/amd64"


### PR DESCRIPTION
That's a cygwin flag for SDK version. I am not 100% sure if it's necessary, but it shuts up the warnings, so let's do it.