### PR TITLE
Update Dockerfile and fix Docker build failed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-FROM golang:latest
+FROM golang:1.18
 
 RUN mkdir /trezord-go
 WORKDIR /trezord-go
-COPY ./scripts/run_in_docker.sh /trezord-go
+COPY . /trezord-go
 
 RUN apt-get update
 RUN apt-get install -y redir
 
-RUN go get github.com/trezor/trezord-go
-RUN go build github.com/trezor/trezord-go
+RUN go build .
 
-ENTRYPOINT '/trezord-go/run_in_docker.sh'
+ENTRYPOINT '/trezord-go/scripts/run_in_docker.sh'
 EXPOSE 11325


### PR DESCRIPTION
**Problem:**
The current Dockerfile doesn't work when building the image. Consequently, the Docker compose file also doesn't work. This problem is caused by following issues.

1. The latest go version (1.21) can't compile the source file `usb/lowlevel/libusb/libusb.go` with these error messages.
```sh
usb/lowlevel/libusb/libusb.go:405:10: cannot define new methods on non-local type *C.struct_libusb_endpoint_descriptor
usb/lowlevel/libusb/libusb.go:455:10: cannot define new methods on non-local type *C.struct_libusb_interface_descriptor
usb/lowlevel/libusb/libusb.go:510:10: cannot define new methods on non-local type *C.struct_libusb_interface
usb/lowlevel/libusb/libusb.go:557:10: cannot define new methods on non-local type *C.struct_libusb_config_descriptor
usb/lowlevel/libusb/libusb.go:615:10: cannot define new methods on non-local type *C.struct_libusb_ss_endpoint_companion_descriptor
usb/lowlevel/libusb/libusb.go:639:10: cannot define new methods on non-local type *C.struct_libusb_bos_dev_capability_descriptor
usb/lowlevel/libusb/libusb.go:662:10: cannot define new methods on non-local type *C.struct_libusb_bos_descriptor
usb/lowlevel/libusb/libusb.go:694:10: cannot define new methods on non-local type *C.struct_libusb_usb_2_0_extension_descriptor
usb/lowlevel/libusb/libusb.go:721:10: cannot define new methods on non-local type *C.struct_libusb_ss_usb_device_capability_descriptor
usb/lowlevel/libusb/libusb.go:749:10: cannot define new methods on non-local type *C.struct_libusb_container_id_descriptor
usb/lowlevel/libusb/libusb.go:796:10: cannot define new methods on non-local type *C.struct_libusb_device_descriptor
usb/lowlevel/libusb/libusb.go:866:10: cannot define new methods on non-local type *C.struct_libusb_transfer
usb/lowlevel/libusb/libusb.go:895:10: cannot define new methods on non-local type *C.struct_libusb_version
```
2. The current build process used `go get` outside of the go module directory. However, `go get` is no longer supported outside a module.

**Solution:**

1. Fix the golang image version to 1.18 to ensure that the image can be successfully built. This is the same version that is used in the repository's GitHub workflow.
2. Instead of using `go get` to get the source code in the image, the whole repository is copied to the image. Previously, only the run script was copied to the image.